### PR TITLE
fix(repro): improve memory and workflow correctness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,22 @@ jobs:
             tests/unit/test_llm_service.py \
             tests/unit/test_di_container.py \
             tests/unit/test_pipeline.py \
+            tests/unit/repro/test_agents.py \
+            tests/unit/repro/test_blueprint.py \
+            tests/unit/repro/test_memory.py \
+            tests/unit/repro/test_orchestrator.py \
+            tests/unit/repro/test_rag.py \
             tests/integration/test_eventlog_sqlalchemy.py \
             tests/integration/test_crawler_contract_parsers.py \
             tests/integration/test_arxiv_connector_fixture.py \
             tests/integration/test_reddit_connector_fixture.py \
             tests/integration/test_x_importer_fixture.py \
+            tests/integration/test_repro_deepcode.py \
+            tests/test_generation_agent.py \
+            tests/test_repro_planning.py \
+            tests/test_repro_agent.py \
+            tests/test_repro_e2e.py \
+            tests/test_repro_models.py \
             tests/e2e/test_api_track_fullstack_offline.py
 
       - name: Run eval smokes

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -12,6 +12,8 @@ lxml>=4.9.0
 PyYAML>=6.0
 pydantic>=2.0.0
 loguru>=0.7.0
+cryptography>=41.0.0
+keyring>=25.0.0
 
 SQLAlchemy>=2.0.0
 alembic>=1.13.0
@@ -38,4 +40,3 @@ aiofiles>=22.1.0
 python-dotenv>=0.19.0
 json-repair>=0.22.0
 uvicorn>=0.32.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ numpy>=1.24.0
 # 配置管理
 pyyaml>=6.0
 python-dotenv>=0.19.0
+cryptography>=41.0.0
+keyring>=25.0.0
 
 # 配置模型
 pydantic>=2.0.0

--- a/src/paperbot/agents/base.py
+++ b/src/paperbot/agents/base.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional
 from abc import ABC, abstractmethod
 import logging
 import os
-from anthropic import AsyncAnthropic
 
 from paperbot.core.abstractions import Executable, ExecutionResult, ensure_execution_result
 from paperbot.core.di import Container
@@ -31,7 +30,14 @@ class BaseAgent(Executable[Dict[str, Any], Dict[str, Any]], ABC, JSONParserMixin
         
         # Initialize Anthropic client
         api_key = self.config.get('anthropic_api_key') or os.getenv('ANTHROPIC_API_KEY')
-        self.client = AsyncAnthropic(api_key=api_key) if api_key else None
+        self.client = None
+        if api_key:
+            try:
+                from anthropic import AsyncAnthropic
+
+                self.client = AsyncAnthropic(api_key=api_key)
+            except Exception as exc:
+                self.logger.warning("Anthropic client unavailable: %s", exc)
 
         # 可选注入的统一 LLMClient（DI）
         try:

--- a/src/paperbot/context_engine/engine.py
+++ b/src/paperbot/context_engine/engine.py
@@ -637,10 +637,6 @@ class ContextEngine:
                 mmr_lambda=self.config.memory_search_mmr_lambda,
                 half_life_days=self.config.memory_search_half_life_days,
             )
-            self.memory_store.touch_usage(
-                item_ids=[int(i["id"]) for i in relevant_memories if i.get("id")],
-                actor_id="context_engine",
-            )
 
         if include_cross_track and track_id is None:
             tracks = self.research_store.list_tracks(
@@ -670,19 +666,12 @@ class ContextEngine:
                     mmr_lambda=self.config.memory_search_mmr_lambda,
                     half_life_days=self.config.memory_search_half_life_days,
                 )
-                cross_hit_ids: List[int] = []
                 for sid, hits in batch_results.items():
                     t = scope_id_to_track.get(sid)
                     for h in hits:
                         h["track_id"] = t.get("id") if t else None
                         h["track_name"] = t.get("name") if t else None
-                        if h.get("id"):
-                            cross_hit_ids.append(int(h["id"]))
                     cross_track_memories.extend(hits)
-                if cross_hit_ids:
-                    self.memory_store.touch_usage(
-                        item_ids=cross_hit_ids, actor_id="context_engine"
-                    )
 
         return {
             "relevant_memories": relevant_memories,

--- a/src/paperbot/core/fail_fast.py
+++ b/src/paperbot/core/fail_fast.py
@@ -169,7 +169,7 @@ class FailFastEvaluator:
             return SkipDecision(
                 should_skip=True,
                 reason=f"阶段 '{lowest.stage}' 评分过低 ({lowest.score:.1f}),提前终止",
-                skipped_stages=["influence", "report"]
+                skipped_stages=["code", "quality", "influence", "report"]
             )
         
         return SkipDecision(should_skip=False, reason="继续执行")

--- a/src/paperbot/core/workflow_coordinator.py
+++ b/src/paperbot/core/workflow_coordinator.py
@@ -16,7 +16,14 @@ from typing import Dict, Any, Optional, List, Tuple, TYPE_CHECKING
 from pathlib import Path
 from dataclasses import dataclass, field
 
-from .collaboration.score_bus import ScoreShareBus, StageScore, create_research_score, create_code_score
+from .collaboration.score_bus import (
+    ScoreShareBus,
+    StageScore,
+    create_code_score,
+    create_influence_score,
+    create_quality_score,
+    create_research_score,
+)
 from .fail_fast import FailFastEvaluator, FailFastConfig
 
 logger = logging.getLogger(__name__)
@@ -190,6 +197,18 @@ class ScholarWorkflowCoordinator:
             
             # P3: 发布研究评分
             self._publish_research_score(ctx)
+
+            if self.enable_fail_fast:
+                early_exit = self.fail_fast_evaluator.evaluate_early_exit(score_bus)
+                if early_exit.should_skip:
+                    logger.info(f"⚡ Fail-Fast: 提前终止流水线 - {early_exit.reason}")
+                    for stage in early_exit.skipped_stages:
+                        if stage not in ctx.skipped_stages:
+                            ctx.skipped_stages.append(stage)
+                        ctx.stages[stage] = {"status": "skipped", "reason": early_exit.reason}
+                    ctx.influence_result = self._create_default_influence()
+                    ctx.status = "success"
+                    return None, ctx.influence_result, self._build_pipeline_data(ctx)
             
             # 检查是否有代码
             has_code = bool(paper.github_url or getattr(paper, 'has_code', False))
@@ -202,6 +221,10 @@ class ScholarWorkflowCoordinator:
                     if skip_decision.should_skip:
                         logger.info(f"⚡ Fail-Fast: 跳过代码分析 - {skip_decision.reason}")
                         ctx.skipped_stages.append("code")
+                        ctx.stages["code_analysis"] = {
+                            "status": "skipped",
+                            "reason": skip_decision.reason,
+                        }
                     else:
                         ctx = await self._run_code_analysis_stage(ctx)
                         self._publish_code_score(ctx)
@@ -215,13 +238,17 @@ class ScholarWorkflowCoordinator:
                 if skip_decision.should_skip:
                     logger.info(f"⚡ Fail-Fast: 跳过质量评估 - {skip_decision.reason}")
                     ctx.skipped_stages.append("quality")
+                    ctx.stages["quality"] = {"status": "skipped", "reason": skip_decision.reason}
                 else:
                     ctx = await self._run_quality_stage(ctx)
+                    self._publish_quality_score(ctx)
             else:
                 ctx = await self._run_quality_stage(ctx)
+                self._publish_quality_score(ctx)
             
             # 4. 影响力计算
             ctx = await self._run_influence_stage(ctx)
+            self._publish_influence_score(ctx)
             
             # 5. 报告生成
             report_path = None
@@ -264,6 +291,68 @@ class ScholarWorkflowCoordinator:
         
         score = create_code_score(has_code, health_score, is_empty)
         ctx.score_bus.publish_score(score)
+
+    def _publish_quality_score(self, ctx: PipelineContext) -> None:
+        """发布质量阶段评分到总线"""
+        if not ctx.score_bus:
+            return
+
+        quality_result = ctx.quality_result or {}
+        quality_scores = quality_result.get("quality_scores") or {}
+        primary_score = {}
+        if isinstance(quality_scores, dict) and quality_scores:
+            first_score = next(iter(quality_scores.values()))
+            if isinstance(first_score, dict):
+                primary_score = first_score
+
+        raw_overall = quality_result.get("quality_score")
+        if raw_overall is None:
+            raw_overall = primary_score.get("overall_score", 0.0)
+
+        overall_score = float(raw_overall or 0.0)
+        if overall_score <= 1.0:
+            overall_score *= 100.0
+
+        metric_scores = primary_score.get("scores") or {}
+        maintainability = float(metric_scores.get("maintainability", 0.0) or 0.0)
+        test_coverage = float(metric_scores.get("test_coverage", 0.0) or 0.0)
+        if maintainability <= 1.0:
+            maintainability *= 100.0
+        if test_coverage <= 1.0:
+            test_coverage *= 100.0
+
+        ctx.score_bus.publish_score(
+            create_quality_score(
+                overall_score,
+                maintainability=maintainability,
+                test_coverage=test_coverage,
+            )
+        )
+
+    def _publish_influence_score(self, ctx: PipelineContext) -> None:
+        """发布影响力阶段评分到总线"""
+        if not ctx.score_bus or ctx.influence_result is None:
+            return
+
+        influence = ctx.influence_result
+        total_score = float(getattr(influence, "total_score", 0.0) or 0.0)
+        academic_score = float(getattr(influence, "academic_score", 0.0) or 0.0)
+        engineering_score = float(getattr(influence, "engineering_score", 0.0) or 0.0)
+        metrics_breakdown = getattr(influence, "metrics_breakdown", {}) or {}
+        momentum_score = 0.0
+        if isinstance(metrics_breakdown, dict):
+            academic_metrics = metrics_breakdown.get("academic") or {}
+            if isinstance(academic_metrics, dict):
+                momentum_score = float(academic_metrics.get("momentum_score", 0.0) or 0.0)
+
+        ctx.score_bus.publish_score(
+            create_influence_score(
+                total_score=total_score,
+                academic_score=academic_score,
+                engineering_score=engineering_score,
+                momentum_score=momentum_score,
+            )
+        )
     
     async def _run_research_stage(self, ctx: PipelineContext) -> PipelineContext:
         """运行研究分析阶段"""
@@ -442,4 +531,3 @@ class ScholarWorkflowCoordinator:
             )
             results.append(result)
         return results
-

--- a/src/paperbot/infrastructure/stores/memory_store.py
+++ b/src/paperbot/infrastructure/stores/memory_store.py
@@ -130,6 +130,15 @@ def _is_evergreen_memory(item: Dict[str, Any]) -> bool:
     return scope_type == "global" or kind == "preference"
 
 
+def _memory_relevance_score(item: Dict[str, Any]) -> float:
+    """Pick the strongest available retrieval relevance score for decay ranking."""
+    for field_name in ("hybrid_score", "vec_score", "confidence"):
+        raw_score = item.get(field_name)
+        if raw_score is not None:
+            return float(raw_score)
+    return 0.5
+
+
 def _decay_score(
     item: Dict[str, Any],
     *,
@@ -151,7 +160,7 @@ def _decay_score(
     if now is None:
         now = datetime.now(timezone.utc)
 
-    relevance = float(item.get("confidence", 0.5))
+    relevance = _memory_relevance_score(item)
 
     # Evergreen memories are immune to time-based decay.
     if _is_evergreen_memory(item):
@@ -947,6 +956,20 @@ class SqlAlchemyMemoryStore:
             if mmr_enabled:
                 grouped[sid] = _apply_mmr_rerank(grouped[sid], lambda_value=mmr_lambda)
             grouped[sid] = grouped[sid][:limit_per_scope]
+
+        hit_ids = sorted(
+            {
+                int(item["id"])
+                for hits in grouped.values()
+                for item in hits
+                if item.get("id")
+            }
+        )
+        if hit_ids:
+            try:
+                self.touch_usage(item_ids=hit_ids, actor_id="search")
+            except Exception:  # noqa: BLE001 — best-effort
+                pass
 
         return grouped
 

--- a/src/paperbot/repro/orchestrator.py
+++ b/src/paperbot/repro/orchestrator.py
@@ -195,93 +195,119 @@ class Orchestrator:
         result = ReproductionResult(paper_title=paper_context.title)
 
         try:
-            # Stage 1: Planning
-            self._update_stage(PipelineStage.PLANNING)
-            planning_result = await self._run_planning()
-
-            if planning_result.status != AgentStatus.COMPLETED:
-                result.status = ReproPhase.FAILED
-                result.error = f"Planning failed: {planning_result.error}"
-                return self._finalize_result(result)
-
-            result.plan = self.context.get("plan")
-            result.phases_completed.append("planning")
-
-            # Stage 2: Coding
-            self._update_stage(PipelineStage.CODING)
-            coding_result = await self._run_coding()
-
-            if coding_result.status != AgentStatus.COMPLETED:
-                result.status = ReproPhase.FAILED
-                result.error = f"Coding failed: {coding_result.error}"
-                return self._finalize_result(result)
-
-            result.generated_files = self.context.get("generated_files", {})
-            result.spec = self.context.get("spec")
-            result.phases_completed.append("generation")
-
-            # Stage 3: Verification + Repair Loop
-            for repair_attempt in range(self.config.max_repair_loops + 1):
-                self.progress.repair_loop_count = repair_attempt
-
-                # Verify
-                self._update_stage(PipelineStage.VERIFICATION)
-                verification_result = await self._run_verification()
-
-                report = self.context.get("verification_report")
-                if report:
-                    result.verification = report.to_dict()
-
-                # Check if verification passed
-                if report and report.all_passed:
-                    result.phases_completed.append("verification")
-                    break
-
-                # Try to repair if we have errors and attempts remaining
-                error = self.context.get("error")
-                if error and repair_attempt < self.config.max_repair_loops:
-                    self._update_stage(PipelineStage.DEBUGGING)
-                    debug_result = await self._run_debugging()
-
-                    result.retry_count += 1
-
-                    if debug_result.status != AgentStatus.COMPLETED:
-                        logger.warning(f"Repair attempt {repair_attempt + 1} failed")
-                        result.errors.append(f"Repair failed: {debug_result.error}")
-
-                    # Update generated files if repairs were made
-                    if debug_result.data and debug_result.data.get("modified_files"):
-                        # Re-read files from disk
-                        if self.config.output_dir:
-                            for filepath in result.generated_files:
-                                file_path = self.config.output_dir / filepath
-                                if file_path.exists():
-                                    result.generated_files[filepath] = file_path.read_text()
-                else:
-                    # No error or no more repair attempts
-                    if error:
-                        result.errors.append(error)
-                    break
-
-            # Determine final status
-            if report and report.all_passed:
-                result.status = ReproPhase.COMPLETED
-            else:
-                result.status = ReproPhase.VERIFICATION
-                if not result.error:
-                    result.error = "Verification did not pass all checks"
-
-            return self._finalize_result(result)
+            timeout_seconds = self._pipeline_timeout_seconds()
+            if timeout_seconds is None:
+                return await self._run_pipeline(result)
+            return await asyncio.wait_for(self._run_pipeline(result), timeout=timeout_seconds)
 
         except asyncio.TimeoutError:
+            self._update_stage(PipelineStage.FAILED)
             result.status = ReproPhase.FAILED
-            result.error = "Pipeline timed out"
+            timeout_seconds = self._pipeline_timeout_seconds()
+            if timeout_seconds is None:
+                result.error = "Pipeline timed out"
+            else:
+                result.error = f"Pipeline timed out after {timeout_seconds:g}s"
             return self._finalize_result(result)
         except Exception as e:
+            self._update_stage(PipelineStage.FAILED)
             logger.error(f"Pipeline failed: {e}")
             result.status = ReproPhase.FAILED
             result.error = str(e)
             return self._finalize_result(result)
+
+    def _pipeline_timeout_seconds(self) -> Optional[float]:
+        """Return the configured pipeline timeout, or ``None`` when disabled."""
+        raw_timeout = self.config.timeout_seconds
+        if raw_timeout is None:
+            return None
+        try:
+            timeout = float(raw_timeout)
+        except (TypeError, ValueError):
+            return None
+        return timeout if timeout > 0 else None
+
+    async def _run_pipeline(self, result: ReproductionResult) -> ReproductionResult:
+        """Execute the Paper2Code pipeline body under the configured timeout."""
+        # Stage 1: Planning
+        self._update_stage(PipelineStage.PLANNING)
+        planning_result = await self._run_planning()
+
+        if planning_result.status != AgentStatus.COMPLETED:
+            result.status = ReproPhase.FAILED
+            result.error = f"Planning failed: {planning_result.error}"
+            return self._finalize_result(result)
+
+        result.plan = self.context.get("plan")
+        result.phases_completed.append("planning")
+
+        # Stage 2: Coding
+        self._update_stage(PipelineStage.CODING)
+        coding_result = await self._run_coding()
+
+        if coding_result.status != AgentStatus.COMPLETED:
+            result.status = ReproPhase.FAILED
+            result.error = f"Coding failed: {coding_result.error}"
+            return self._finalize_result(result)
+
+        result.generated_files = self.context.get("generated_files", {})
+        result.spec = self.context.get("spec")
+        result.phases_completed.append("generation")
+
+        report = None
+
+        # Stage 3: Verification + Repair Loop
+        for repair_attempt in range(self.config.max_repair_loops + 1):
+            self.progress.repair_loop_count = repair_attempt
+
+            # Verify
+            self._update_stage(PipelineStage.VERIFICATION)
+            await self._run_verification()
+
+            report = self.context.get("verification_report")
+            if report:
+                result.verification = report.to_dict()
+
+            # Check if verification passed
+            if report and report.all_passed:
+                result.phases_completed.append("verification")
+                break
+
+            # Try to repair if we have errors and attempts remaining
+            error = self.context.get("error")
+            if error and repair_attempt < self.config.max_repair_loops:
+                self._update_stage(PipelineStage.DEBUGGING)
+                debug_result = await self._run_debugging()
+
+                result.retry_count += 1
+
+                if debug_result.status != AgentStatus.COMPLETED:
+                    logger.warning(f"Repair attempt {repair_attempt + 1} failed")
+                    result.errors.append(f"Repair failed: {debug_result.error}")
+
+                # Update generated files if repairs were made
+                if debug_result.data and debug_result.data.get("modified_files"):
+                    # Re-read files from disk
+                    if self.config.output_dir:
+                        for filepath in result.generated_files:
+                            file_path = self.config.output_dir / filepath
+                            if file_path.exists():
+                                result.generated_files[filepath] = file_path.read_text()
+            else:
+                # No error or no more repair attempts
+                if error:
+                    result.errors.append(error)
+                break
+
+        # Determine final status
+        if report and report.all_passed:
+            result.status = ReproPhase.COMPLETED
+        else:
+            result.status = ReproPhase.VERIFICATION
+            if not result.error:
+                result.error = "Verification did not pass all checks"
+
+        return self._finalize_result(result)
 
     async def _run_planning(self) -> AgentResult:
         """Run planning agent."""

--- a/src/paperbot/repro/repro_agent.py
+++ b/src/paperbot/repro/repro_agent.py
@@ -220,6 +220,10 @@ class ReproAgent:
         ):
             config = OrchestratorConfig(
                 max_repair_loops=self.config.get("max_repair_attempts", 3),
+                timeout_seconds=self.config.get(
+                    "orchestrator_timeout_seconds",
+                    self.config.get("timeout_sec", 300),
+                ),
                 output_dir=output_dir,
                 use_rag=self.config.get("use_rag", True),
                 max_context_tokens=self.config.get("max_context_tokens", 8000),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,7 @@ if str(project_root) not in sys.path:
 collect_ignore = [
     str(Path(__file__).parent / "test_code_analysis_fallback.py"),
     str(Path(__file__).parent / "test_conference_agent_stats.py"),
-    str(Path(__file__).parent / "test_generation_agent.py"),
     str(Path(__file__).parent / "test_influence_recency.py"),
     str(Path(__file__).parent / "test_literature_grounding.py"),
     str(Path(__file__).parent / "test_render_report_latest.py"),
-    str(Path(__file__).parent / "test_repro_planning.py"),
 ]

--- a/tests/integration/test_repro_deepcode.py
+++ b/tests/integration/test_repro_deepcode.py
@@ -1,316 +1,160 @@
-# tests/integration/test_repro_deepcode.py
-"""
-Integration tests for DeepCode-enhanced repro pipeline.
-Tests the full flow from paper context to code generation.
-"""
+"""Integration coverage for the current DeepCode-style repro stack."""
 
-import sys
-from unittest.mock import MagicMock, patch, AsyncMock
+from __future__ import annotations
 
-# Mock external dependencies
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
-
-import unittest
-import asyncio
-import tempfile
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from repro import (
-    ReproAgent,
-    PaperContext,
+    AgentResult,
     Blueprint,
-    CodeMemory,
     CodeKnowledgeBase,
+    CodeMemory,
+    EnvironmentSpec,
+    GenerationNode,
+    ImplementationSpec,
+    NodeResult,
     Orchestrator,
     OrchestratorConfig,
+    PaperContext,
+    ReproAgent,
+    ReproductionPlan,
     ReproPhase,
 )
-from repro.nodes import BlueprintDistillationNode, PlanningNode, GenerationNode
-from repro.agents import AgentResult, AgentStatus
 
 
-class TestDeepCodePipelineIntegration(unittest.TestCase):
-    """Integration tests for the full DeepCode pipeline."""
+@pytest.fixture
+def paper_context():
+    return PaperContext(
+        title="Attention Is All You Need",
+        abstract=(
+            "We propose a new simple network architecture, the Transformer, "
+            "based solely on attention mechanisms."
+        ),
+        method_section=(
+            "The Transformer follows an encoder-decoder structure using stacked "
+            "self-attention and point-wise fully connected layers."
+        ),
+        hyperparameters={"d_model": 512, "n_heads": 8, "n_layers": 6},
+    )
 
-    def setUp(self):
-        self.paper_context = PaperContext(
-            title="Attention Is All You Need",
-            abstract="""
-            We propose a new simple network architecture, the Transformer,
-            based solely on attention mechanisms, dispensing with recurrence
-            and convolutions entirely. The dominant sequence transduction
-            models are based on complex recurrent or convolutional neural
-            networks that include an encoder and a decoder.
-            """,
-            method_section="""
-            The Transformer follows an encoder-decoder structure using
-            stacked self-attention and point-wise, fully connected layers.
-            The encoder maps an input sequence to a sequence of continuous
-            representations. The decoder generates an output sequence.
-            """,
-            hyperparameters={"d_model": 512, "n_heads": 8, "n_layers": 6},
-        )
 
-    def test_memory_and_rag_integration(self):
-        """Test that CodeMemory and RAG work together."""
-        memory = CodeMemory(max_context_tokens=2000)
-        kb = CodeKnowledgeBase.from_builtin()
+def test_memory_and_rag_integration():
+    memory = CodeMemory(max_context_tokens=2000)
+    knowledge_base = CodeKnowledgeBase.from_builtin()
 
-        # Add a config file
-        config_code = '''
-class Config:
-    d_model = 512
-    n_heads = 8
-'''
-        memory.add_file("config.py", config_code, purpose="Configuration")
+    memory.add_file(
+        "config.py",
+        "class Config:\n    d_model = 512\n    n_heads = 8\n",
+        purpose="Configuration",
+    )
+    patterns = knowledge_base.search("transformer attention", k=2)
+    context = memory.get_relevant_context("model.py", "Transformer model")
 
-        # Search for related patterns
-        patterns = kb.search("transformer attention", k=2)
-        self.assertGreater(len(patterns), 0)
+    assert patterns
+    assert "config.py" in context
 
-        # Get context for model generation
-        context = memory.get_relevant_context("model.py", "Transformer model")
-        self.assertIn("config.py", context)
 
-    def test_blueprint_to_plan_flow(self):
-        """Test Blueprint distillation to planning flow."""
-        blueprint = Blueprint(
-            architecture_type="transformer",
-            domain="nlp",
-            key_hyperparameters={"d_model": 512, "n_heads": 8},
-            loss_functions=["cross_entropy"],
-            framework_hints=["pytorch"],
-        )
+def test_generation_node_initializes_memory_and_knowledge_base():
+    node = GenerationNode(max_context_tokens=2000, use_rag=True)
 
-        # Blueprint should be convertible to planning context
-        context = blueprint.to_compressed_context()
+    assert node.memory is not None
+    assert node.knowledge_base is not None
+    assert node.memory.max_context_tokens == 2000
 
-        self.assertIn("transformer", context)
-        self.assertIn("nlp", context)
-        self.assertIn("d_model", context)
 
-    def test_generation_with_memory(self):
-        """Test that GenerationNode uses CodeMemory correctly."""
-        node = GenerationNode(max_context_tokens=2000, use_rag=True)
+def test_repro_agent_mode_switching():
+    legacy_agent = ReproAgent({"use_orchestrator": False})
+    orchestrated_agent = ReproAgent({"use_orchestrator": True})
 
-        # Verify memory is initialized
-        self.assertIsNotNone(node.memory)
-        self.assertIsNotNone(node.knowledge_base)
+    assert legacy_agent.use_orchestrator is False
+    assert orchestrated_agent.use_orchestrator is True
 
-        # Verify token budget is respected
-        self.assertEqual(node.memory.max_context_tokens, 2000)
 
-    def test_orchestrator_initialization(self):
-        """Test Orchestrator initializes all agents correctly."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            config = OrchestratorConfig(
-                max_repair_loops=2,
-                output_dir=Path(tmpdir),
-                use_rag=True,
-            )
+@pytest.mark.asyncio
+async def test_orchestrator_mock_pipeline_completes(tmp_path, paper_context):
+    orchestrator = Orchestrator(config=OrchestratorConfig(max_repair_loops=1, output_dir=tmp_path))
+    mock_plan = MagicMock()
+    mock_plan.file_structure = {"main.py": "entry", "model.py": "model"}
 
-            orchestrator = Orchestrator(config=config)
+    async def planning_run(context):
+        context["plan"] = mock_plan
+        context["blueprint"] = Blueprint(architecture_type="transformer", domain="nlp")
+        return AgentResult.success(data={"plan": mock_plan})
 
-            self.assertIsNotNone(orchestrator.planning_agent)
-            self.assertIsNotNone(orchestrator.coding_agent)
-            self.assertIsNotNone(orchestrator.verification_agent)
-            self.assertIsNotNone(orchestrator.debugging_agent)
-
-    def test_repro_agent_mode_switching(self):
-        """Test ReproAgent can switch between legacy and orchestrator modes."""
-        # Legacy mode
-        agent_legacy = ReproAgent({"use_orchestrator": False})
-        self.assertFalse(agent_legacy.use_orchestrator)
-
-        # Orchestrator mode
-        agent_orch = ReproAgent({"use_orchestrator": True})
-        self.assertTrue(agent_orch.use_orchestrator)
-
-    def test_full_pipeline_mock(self):
-        """Test full pipeline with mocked LLM calls."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            config = OrchestratorConfig(
-                max_repair_loops=1,
-                output_dir=Path(tmpdir),
-            )
-
-            orchestrator = Orchestrator(config=config)
-
-            # Mock all agent runs
-            mock_plan = MagicMock()
-            mock_plan.file_structure = {"main.py": "entry", "model.py": "model"}
-
-            async def mock_planning(context):
-                context["plan"] = mock_plan
-                context["blueprint"] = Blueprint(
-                    architecture_type="transformer",
-                    domain="nlp",
-                )
-                return AgentResult.success(data={"plan": mock_plan})
-
-            async def mock_coding(context):
-                context["generated_files"] = {
-                    "main.py": "print('hello')",
-                    "model.py": "class Model: pass",
-                }
-                # Write files to disk
-                output_dir = context.get("output_dir", Path(tmpdir))
-                for name, content in context["generated_files"].items():
-                    (output_dir / name).write_text(content)
-                return AgentResult.success(data={"generated_files": context["generated_files"]})
-
-            mock_report = MagicMock()
-            mock_report.all_passed = True
-            mock_report.to_dict.return_value = {"syntax_ok": True, "imports_ok": True}
-
-            async def mock_verification(context):
-                context["verification_report"] = mock_report
-                return AgentResult.success(data={"report": mock_report})
-
-            orchestrator.planning_agent.run = mock_planning
-            orchestrator.coding_agent.run = mock_coding
-            orchestrator.verification_agent.run = mock_verification
-
-            result = asyncio.run(orchestrator.run(self.paper_context))
-
-            self.assertEqual(result.status, ReproPhase.COMPLETED)
-            self.assertIn("planning", result.phases_completed)
-            self.assertIn("generation", result.phases_completed)
-
-    def test_dependency_ordering(self):
-        """Test that files are generated in correct dependency order."""
-        memory = CodeMemory()
-
-        file_structure = {
-            "main.py": "entry point",
-            "trainer.py": "training logic",
-            "model.py": "neural network",
-            "config.py": "configuration",
-            "data.py": "data loading",
-            "utils.py": "utilities",
+    async def coding_run(context):
+        context["generated_files"] = {
+            "main.py": "print('hello')",
+            "model.py": "class Model: pass",
         }
+        for name, content in context["generated_files"].items():
+            (tmp_path / name).write_text(content)
+        return AgentResult.success(data={"generated_files": context["generated_files"]})
 
-        order = memory.compute_generation_order(file_structure)
+    report = SimpleNamespace(
+        all_passed=True,
+        to_dict=lambda: {"syntax_ok": True, "imports_ok": True},
+    )
 
-        # Config should come before model
-        self.assertLess(order.index("config.py"), order.index("model.py"))
+    async def verification_run(context):
+        context["verification_report"] = report
+        return AgentResult.success(data={"report": report})
 
-        # Model should come before trainer
-        self.assertLess(order.index("model.py"), order.index("trainer.py"))
+    orchestrator.planning_agent.run = planning_run
+    orchestrator.coding_agent.run = coding_run
+    orchestrator.verification_agent.run = verification_run
 
-        # Main should be last
-        self.assertEqual(order.index("main.py"), len(order) - 1)
+    result = await orchestrator.run(paper_context)
 
-    def test_symbol_tracking_across_files(self):
-        """Test that symbols are tracked correctly across files."""
-        memory = CodeMemory()
-
-        # Add config with class definition
-        memory.add_file(
-            "config.py",
-            '''class Config:
-    hidden_size = 256
-    learning_rate = 0.001
-''',
-            purpose="Configuration",
-        )
-
-        # Add model with class definition
-        memory.add_file(
-            "model.py",
-            '''class Model:
-    def __init__(self):
-        self.size = 256
-''',
-            purpose="Model",
-        )
-
-        # Verify symbols are indexed
-        config_symbol = memory._symbol_index.get_symbol("Config")
-        self.assertIsNotNone(config_symbol)
-        self.assertEqual(config_symbol.kind, "class")
-
-        model_symbol = memory._symbol_index.get_symbol("Model")
-        self.assertIsNotNone(model_symbol)
-        self.assertEqual(model_symbol.kind, "class")
-
-    def test_rag_pattern_injection(self):
-        """Test that RAG patterns are retrieved and used."""
-        kb = CodeKnowledgeBase.from_builtin()
-
-        # Search for training patterns
-        patterns = kb.search("pytorch training loop validation", k=3)
-
-        self.assertGreater(len(patterns), 0)
-
-        # Verify patterns have code
-        for pattern in patterns:
-            self.assertTrue(len(pattern.code) > 0)
-            self.assertTrue(len(pattern.tags) > 0)
-
-        # Get pattern context
-        context = patterns[0].to_context()
-        self.assertIn("Pattern:", context)
+    assert result.status is ReproPhase.COMPLETED
+    assert "planning" in result.phases_completed
+    assert "generation" in result.phases_completed
+    assert (tmp_path / "main.py").read_text() == "print('hello')"
 
 
-class TestReproAgentE2E(unittest.TestCase):
-    """End-to-end tests for ReproAgent."""
-
-    def setUp(self):
-        self.paper_context = PaperContext(
-            title="Simple MLP Classifier",
-            abstract="We propose a simple MLP for classification.",
-            method_section="The model consists of fully connected layers.",
-        )
-
-    def test_legacy_mode_runs(self):
-        """Test that legacy mode still works."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            agent = ReproAgent({
-                "use_orchestrator": False,
-                "timeout_sec": 10,
-            })
-
-            # Mock the nodes to avoid LLM calls
-            agent.planning_node.run = AsyncMock(return_value=MagicMock(
-                success=True,
-                data=MagicMock(
+@pytest.mark.asyncio
+async def test_repro_agent_legacy_mode_runs_with_mocked_nodes(paper_context):
+    with TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+        agent = ReproAgent({"use_orchestrator": False, "timeout_sec": 10})
+        agent.planning_node.run = AsyncMock(
+            return_value=NodeResult.ok(
+                ReproductionPlan(
+                    project_name="Attention Is All You Need",
+                    description="Transformer reproduction",
                     file_structure={"main.py": "entry"},
-                    entry_point="main.py",
                     dependencies=[],
-                    key_components=[],
-                ),
-            ))
-
-            agent.environment_node.run = AsyncMock(return_value=MagicMock(
-                success=True,
-                data=MagicMock(
+                )
+            )
+        )
+        agent.environment_node.run = AsyncMock(
+            return_value=NodeResult.ok(
+                EnvironmentSpec(
                     python_version="3.10",
                     base_image="python:3.10-slim",
                     pip_requirements=[],
-                ),
-            ))
-
-            agent.analysis_node.run = AsyncMock(return_value=MagicMock(
-                success=True,
-                data=MagicMock(
+                )
+            )
+        )
+        agent.analysis_node.run = AsyncMock(
+            return_value=NodeResult.ok(
+                ImplementationSpec(
                     model_type="mlp",
                     layers=[],
                     optimizer="adam",
                     extra_params={},
-                ),
-            ))
-
-            agent.generation_node.run = AsyncMock(return_value=MagicMock(
+                )
+            )
+        )
+        agent.generation_node.run = AsyncMock(return_value=NodeResult.ok({"main.py": "print('hello')"}))
+        agent.verification_node.run = AsyncMock(
+            return_value=SimpleNamespace(
                 success=True,
-                data={"main.py": "print('hello')"},
-            ))
-
-            agent.verification_node.run = AsyncMock(return_value=MagicMock(
-                success=True,
-                data=MagicMock(
+                data=SimpleNamespace(
                     all_passed=True,
                     syntax_ok=True,
                     imports_ok=True,
@@ -319,30 +163,26 @@ class TestReproAgentE2E(unittest.TestCase):
                     repairs_successful=0,
                     to_dict=lambda: {"all_passed": True},
                 ),
-            ))
+            )
+        )
 
-            result = asyncio.run(agent.reproduce_from_paper(
-                self.paper_context,
-                output_dir=Path(tmpdir),
-            ))
+        result = await agent.reproduce_from_paper(paper_context, output_dir=output_dir)
 
-            # Should complete
-            self.assertIn("planning", result.phases_completed)
-
-    def test_orchestrator_mode_init(self):
-        """Test that orchestrator mode initializes correctly."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            agent = ReproAgent({
-                "use_orchestrator": True,
-                "use_rag": True,
-                "max_context_tokens": 4000,
-            })
-
-            orchestrator = agent.get_orchestrator(Path(tmpdir))
-
-            self.assertIsNotNone(orchestrator)
-            self.assertTrue(orchestrator.config.use_rag)
+    assert result.status is ReproPhase.COMPLETED
+    assert "planning" in result.phases_completed
+    assert "generation" in result.phases_completed
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_repro_agent_orchestrator_mode_init(tmp_path):
+    agent = ReproAgent(
+        {
+            "use_orchestrator": True,
+            "use_rag": True,
+            "max_context_tokens": 4000,
+        }
+    )
+
+    orchestrator = agent.get_orchestrator(tmp_path)
+
+    assert orchestrator is not None
+    assert orchestrator.config.use_rag is True

--- a/tests/test_generation_agent.py
+++ b/tests/test_generation_agent.py
@@ -1,50 +1,57 @@
-import sys
-from unittest.mock import MagicMock
+"""Compatibility tests for the current repro code-generation layer."""
 
-# Mock dependencies before importing modules under test
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["claude_agent_sdk"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
+from __future__ import annotations
 
-import unittest
-from unittest.mock import patch
-from repro.generation_agent import GenerationAgent
-from repro.models import PaperContext, ReproductionPlan, ImplementationSpec
+from repro import Blueprint, GenerationNode, ImplementationSpec, ReproductionPlan
 
-class TestGenerationAgent(unittest.TestCase):
-    def setUp(self):
-        self.agent = GenerationAgent()
-        self.ctx = PaperContext(title="Test", abstract="Abs")
-        self.plan = ReproductionPlan(
-            project_name="test",
-            description="desc",
-            file_structure={"main.py": "Main file"},
-            entry_point="main.py"
-        )
-        self.spec = ImplementationSpec(model_type="mlp")
 
-    def test_fallback_template(self):
-        # Test fallback templates
-        code = self.agent._fallback_template("main.py", "Main", self.plan, self.spec)
-        self.assertIn("import argparse", code)
-        
-        code = self.agent._fallback_template("unknown.py", "Unknown", self.plan, self.spec)
-        self.assertIn("# TODO: Implement", code)
+def test_generation_node_fallback_templates_cover_known_and_generic_files():
+    node = GenerationNode()
+    plan = ReproductionPlan(
+        project_name="test",
+        description="desc",
+        file_structure={"main.py": "Main file"},
+        entry_point="main.py",
+        dependencies=["torch", "numpy"],
+    )
+    spec = ImplementationSpec(model_type="mlp")
 
-    def test_generate_requirements(self):
-        reqs = self.agent._generate_requirements(self.plan)
-        self.assertIn("torch", reqs)
-        self.assertIn("numpy", reqs)
+    main_code = node._fallback_template("main.py", "Main file", plan, spec)
+    generic_code = node._fallback_template("unknown.py", "Unknown file", plan, spec)
 
-    def test_clean_code_response(self):
-        raw = "```python\nprint('hello')\n```"
-        clean = self.agent._clean_code_response(raw)
-        self.assertEqual(clean, "print('hello')")
-        
-        raw2 = "print('hello')"
-        clean2 = self.agent._clean_code_response(raw2)
-        self.assertEqual(clean2, "print('hello')")
+    assert "import argparse" in main_code
+    assert "# TODO: Implement unknown" in generic_code
 
-if __name__ == "__main__":
-    unittest.main()
+
+def test_generation_node_generate_requirements_uses_plan_dependencies():
+    node = GenerationNode()
+    plan = ReproductionPlan(
+        project_name="test",
+        description="desc",
+        dependencies=["torch", "numpy"],
+    )
+
+    requirements = node._generate_requirements(plan)
+
+    assert requirements.splitlines() == ["torch", "numpy"]
+
+
+def test_generation_node_clean_code_strips_markdown_fences():
+    node = GenerationNode()
+
+    assert node._clean_code("```python\nprint('hello')\n```") == "print('hello')"
+    assert node._clean_code("print('hello')") == "print('hello')"
+
+
+def test_generation_node_retrieves_patterns_from_blueprint_hints():
+    node = GenerationNode(use_rag=True)
+    blueprint = Blueprint(
+        architecture_type="transformer",
+        framework_hints=["pytorch"],
+        domain="nlp",
+    )
+
+    patterns = node._retrieve_patterns("model.py", "Model implementation", blueprint)
+
+    assert patterns
+    assert any(pattern.name for pattern in patterns)

--- a/tests/test_repro_agent.py
+++ b/tests/test_repro_agent.py
@@ -1,65 +1,146 @@
-import sys
-from unittest.mock import MagicMock, patch, AsyncMock
+"""Tests for the public repro agent APIs."""
 
-# Mock dependencies before importing modules under test
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["claude_agent_sdk"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
+from __future__ import annotations
 
-import unittest
-import asyncio
 from pathlib import Path
-from repro.repro_agent import ReproAgent
-from repro.models import PaperContext, ReproductionResult, ReproPhase
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
-class DummyExecutor:
-    def __init__(self, status="success"):
-        self._status = status
+import pytest
 
-    def available(self):
+from repro import (
+    EnvironmentSpec,
+    ExecutionResult,
+    ImplementationSpec,
+    NodeResult,
+    Orchestrator,
+    PaperContext,
+    ReproAgent,
+    ReproductionPlan,
+    ReproductionResult,
+    ReproPhase,
+)
+
+
+class FakeExecutor:
+    def __init__(self, result: ExecutionResult | None = None):
+        self.result = result or ExecutionResult(status="success", exit_code=0, logs="ok")
+        self.calls = []
+
+    def available(self) -> bool:
         return True
 
-    def run(self, workdir: Path, commands, timeout_sec: int = 300, cache_dir=None):
-        return {
-            "status": self._status,
-            "exit_code": 0 if self._status == "success" else 1,
-            "logs": "ok",
-            "duration_sec": 1.0,
-        }
+    def run(
+        self,
+        workdir: Path,
+        commands,
+        timeout_sec: int = 300,
+        cache_dir=None,
+        record_meta: bool = True,
+    ):
+        self.calls.append((workdir, commands, timeout_sec))
+        return self.result
 
-class TestReproAgent(unittest.TestCase):
-    def setUp(self):
-        self.agent = ReproAgent({})
-        self.agent.executor = DummyExecutor()
-        self.ctx = PaperContext(title="Test", abstract="Abs")
 
-    def test_legacy_run(self):
-        # Test backward compatibility
-        with patch.object(self.agent, 'generate_plan', new_callable=AsyncMock) as mock_plan:
-            mock_plan.return_value = ["echo hello"]
-            res = asyncio.run(self.agent.run(Path(".")))
-            self.assertEqual(res["status"], "success")
+def _verification_report(
+    *,
+    all_passed: bool,
+    syntax_ok: bool,
+    imports_ok: bool,
+    repairs_attempted: int = 0,
+):
+    return SimpleNamespace(
+        all_passed=all_passed,
+        syntax_ok=syntax_ok,
+        imports_ok=imports_ok,
+        errors=[] if all_passed else ["verification failed"],
+        repairs_attempted=repairs_attempted,
+        repairs_successful=repairs_attempted if all_passed else 0,
+        to_dict=lambda: {
+            "all_passed": all_passed,
+            "syntax_ok": syntax_ok,
+            "imports_ok": imports_ok,
+        },
+    )
 
-    def test_paper2code_flow(self):
-        # Test multi-phase reproduction
-        # Mock sub-agents to avoid LLM calls
-        self.agent.planning_agent.generate_plan = AsyncMock(return_value=MagicMock(
-            file_structure={"main.py": "purpose"}
-        ))
-        self.agent.planning_agent.generate_spec = AsyncMock(return_value=MagicMock())
-        self.agent.generation_agent.generate_code = AsyncMock(return_value={"main.py": "print('hi')"})
-        
-        # Also mock internal verification to avoid docker calls that might fail if not fully mocked
-        self.agent._verify_with_retry = AsyncMock(return_value=([], 0))
-        
-        # Run
-        res = asyncio.run(self.agent.reproduce_from_paper(self.ctx))
-        
-        self.assertEqual(res.status, "failed") # Defaults to failed if score is low (verification skipped means 0 score)
-        self.assertIn(ReproPhase.PLANNING.value, res.phases_completed)
-        self.assertIn(ReproPhase.VERIFICATION.value, res.phases_completed)
-        self.assertTrue(res.generated_files)
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.asyncio
+async def test_legacy_run_executes_generated_plan():
+    agent = ReproAgent({})
+    agent.executor = FakeExecutor()
+    agent.generate_plan = AsyncMock(return_value={"commands": ["echo hello"], "repo_path": "."})
+
+    result = await agent.run(Path("."))
+
+    assert result["passed"] is True
+    assert result["results"][0]["commands"] == ["echo hello"]
+    assert result["score"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_reproduce_from_paper_legacy_pipeline_writes_files(tmp_path):
+    agent = ReproAgent({"use_orchestrator": False})
+    agent.planning_node.run = AsyncMock(
+        return_value=NodeResult.ok(
+            ReproductionPlan(
+                project_name="Test",
+                description="desc",
+                file_structure={"main.py": "entry"},
+                dependencies=["numpy"],
+            )
+        )
+    )
+    agent.environment_node.run = AsyncMock(
+        return_value=NodeResult.ok(
+            EnvironmentSpec(base_image="python:3.10-slim", pip_requirements=["numpy"])
+        )
+    )
+    agent.analysis_node.run = AsyncMock(
+        return_value=NodeResult.ok(ImplementationSpec(model_type="mlp", extra_params={}))
+    )
+    agent.generation_node.run = AsyncMock(return_value=NodeResult.ok({"main.py": "print('hello')"}))
+    agent.verification_node.run = AsyncMock(
+        return_value=NodeResult.ok(
+            _verification_report(all_passed=True, syntax_ok=True, imports_ok=True)
+        )
+    )
+
+    result = await agent.reproduce_from_paper(
+        PaperContext(title="Test", abstract="Abs", method_section="Method"),
+        output_dir=tmp_path,
+    )
+
+    assert result.status is ReproPhase.COMPLETED
+    assert result.generated_files == {"main.py": "print('hello')"}
+    assert (tmp_path / "main.py").read_text() == "print('hello')"
+    assert "planning" in result.phases_completed
+    assert "generation" in result.phases_completed
+    assert "verification" in result.phases_completed
+
+
+@pytest.mark.asyncio
+async def test_reproduce_from_paper_uses_orchestrator_mode_when_enabled(tmp_path):
+    agent = ReproAgent({"use_orchestrator": True})
+    expected = ReproductionResult(
+        paper_title="Test",
+        status=ReproPhase.COMPLETED,
+        phases_completed=["planning", "generation", "verification"],
+    )
+    agent._reproduce_with_orchestrator = AsyncMock(return_value=expected)
+
+    result = await agent.reproduce_from_paper(
+        PaperContext(title="Test", abstract="Abs"),
+        output_dir=tmp_path,
+    )
+
+    assert result is expected
+    agent._reproduce_with_orchestrator.assert_awaited_once()
+
+
+def test_get_orchestrator_propagates_timeout_config(tmp_path):
+    agent = ReproAgent({"use_orchestrator": True, "timeout_sec": 42})
+
+    orchestrator = agent.get_orchestrator(tmp_path)
+
+    assert isinstance(orchestrator, Orchestrator)
+    assert orchestrator.config.timeout_seconds == 42

--- a/tests/test_repro_e2e.py
+++ b/tests/test_repro_e2e.py
@@ -1,159 +1,135 @@
-import sys
-from unittest.mock import MagicMock, AsyncMock, patch
+"""End-to-end style tests for the legacy repro pipeline control flow."""
 
-# Mock dependencies before importing modules under test
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["claude_agent_sdk"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
+from __future__ import annotations
 
-import unittest
-import asyncio
-import tempfile
-import shutil
-from pathlib import Path
-from repro.repro_agent import ReproAgent
-from repro.models import PaperContext, VerificationStep
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
-class TestReproE2E(unittest.TestCase):
-    """
-    End-to-End test for PaperBot Repro Pipeline coverage critical paths:
-    1. Happy Path: Plan -> Gen -> Verify(Success)
-    2. Retry Path: Plan -> Gen -> Verify(Fail) -> Refine -> Verify(Success)
-    3. Failure Path: Plan -> Gen -> Verify(Fail) -> Refine(Fail)
-    """
-    
-    def setUp(self):
-        self.test_dir = Path(tempfile.mkdtemp())
-        
-        # Patch dependencies
-        self.patches = [
-            patch('repro.planning_agent.query', None),
-            patch('repro.generation_agent.query', None),
-            patch('repro.repro_agent.query', None)
-        ]
-        for p in self.patches:
-            p.start()
+import pytest
 
-        # Helper to reset agent for each test
-        self.setup_agent()
-        
-    def tearDown(self):
-        shutil.rmtree(self.test_dir)
-        for p in self.patches:
-            p.stop()
+from repro import (
+    EnvironmentSpec,
+    ImplementationSpec,
+    NodeResult,
+    PaperContext,
+    ReproAgent,
+    ReproductionPlan,
+    ReproPhase,
+)
 
-    def setup_agent(self):
-        # We need to forcefully reload or reset the classes if they were imported before patches
-        # But simpler is to rely on the patches being active when the methods are called
-        self.agent = ReproAgent({})
-        self.ctx = PaperContext(
-            title="E2E Paper", 
-            abstract="Abstract", 
-            method_section="Method"
+
+def _legacy_agent_with_common_nodes():
+    agent = ReproAgent({"use_orchestrator": False})
+    agent.planning_node.run = AsyncMock(
+        return_value=NodeResult.ok(
+            ReproductionPlan(
+                project_name="E2E Paper",
+                description="Abstract",
+                file_structure={"main.py": "entry"},
+                dependencies=[],
+            )
         )
-        # Mock executor by default (can be overridden in tests)
-        self.agent.executor = MagicMock()
-        self.agent.executor.available.return_value = True
-
-    def test_happy_path(self):
-        """Test complete success path without retries."""
-        # Setup: Executor always returns success
-        self.agent.executor.run.return_value = {
-            "status": "success", "exit_code": 0, "logs": "OK"
-        }
-        
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        result = loop.run_until_complete(
-            self.agent.reproduce_from_paper(self.ctx, output_dir=self.test_dir)
+    )
+    agent.environment_node.run = AsyncMock(
+        return_value=NodeResult.ok(
+            EnvironmentSpec(base_image="python:3.10-slim", pip_requirements=[])
         )
-        
-        self.assertEqual(result.status, "success")
-        self.assertEqual(result.retry_count, 0)
-        self.assertTrue((self.test_dir / "main.py").exists())
+    )
+    agent.analysis_node.run = AsyncMock(
+        return_value=NodeResult.ok(ImplementationSpec(model_type="mlp", extra_params={}))
+    )
+    agent.generation_node.run = AsyncMock(
+        return_value=NodeResult.ok({"main.py": "print('generated')"})
+    )
+    return agent
 
-    def test_retry_logic_syntax_error(self):
-        """
-        Test Critical Path: Code has syntax error, agent refines it, then passes.
-        """
-        # Mock GenerationAgent.refine_code to return fixed code
-        self.agent.generation_agent.refine_code = AsyncMock(
-            return_value="print('Fixed Syntax')"
-        )
-        
-        # Mock Executor to fail first (syntax check), then succeed
-        # Phase 4 calls: Syntax -> Import -> Test -> Smoke
-        # We want: 
-        # Attempt 1: Syntax Fails
-        # Refine called
-        # Attempt 2: All Succeed
-        
-        # Side effect for executor.run
-        # We need to handle multiple calls. 
-        # Call 1: Syntax check (Fail)
-        # Call 2: Syntax check (Success) -> Call 3: Import (Success) ...
-        
-        # Note: ReproAgent._check_syntax calls executor with "python -m py_compile"
-        def executor_side_effect(workdir, cmd, **kwargs):
-            command_str = cmd[0] if isinstance(cmd, list) else cmd
-            
-            if "py_compile" in command_str:
-                # If content is "Fixed Syntax", succeed, else fail
-                # In real run, file content changes. In mock, we can check a counter or file content
-                main_py = workdir / "main.py"
-                if main_py.exists() and "Fixed" in main_py.read_text():
-                    return {"status": "success", "exit_code": 0, "logs": ""}
-                else:
-                    return {"status": "failed", "exit_code": 1, "logs": "SyntaxError: invalid syntax"}
-            
-            # All other checks pass
-            return {"status": "success", "exit_code": 0, "logs": "OK"}
 
-        self.agent.executor.run.side_effect = executor_side_effect
-        
-        # Create initial dummy file that "has error" (by not having "Fixed")
-        # The generation agent (fallback) creates valid code, but our mock verify logic 
-        # treats it as invalid unless it has "Fixed".
-        
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        result = loop.run_until_complete(
-            self.agent.reproduce_from_paper(self.ctx, output_dir=self.test_dir)
-        )
-        
-        self.assertEqual(result.status, "success")
-        self.assertGreater(result.retry_count, 0, "Should have retried at least once")
-        
-        # Verify Refine was called
-        # self.agent.generation_agent.refine_code.assert_called() 
-        # (It's part of the loop, hard to assert exact call without more mocking, but result implies it)
-        
-        # Verify file was updated
-        self.assertIn("Fixed", (self.test_dir / "main.py").read_text())
+def _report(
+    *,
+    all_passed: bool,
+    syntax_ok: bool,
+    imports_ok: bool,
+    errors=None,
+    repairs_attempted: int = 0,
+):
+    return SimpleNamespace(
+        all_passed=all_passed,
+        syntax_ok=syntax_ok,
+        imports_ok=imports_ok,
+        errors=errors or [],
+        repairs_attempted=repairs_attempted,
+        repairs_successful=repairs_attempted if all_passed else 0,
+        to_dict=lambda: {
+            "all_passed": all_passed,
+            "syntax_ok": syntax_ok,
+            "imports_ok": imports_ok,
+            "errors": errors or [],
+        },
+    )
 
-    def test_unrecoverable_failure(self):
-        """Test path where max retries are exceeded."""
-        self.agent.max_retries = 1
-        
-        # Executor always fails
-        self.agent.executor.run.return_value = {
-            "status": "failed", "exit_code": 1, "logs": "Fatal Error"
-        }
-        
-        # Refine always returns same code (not fixed)
-        self.agent.generation_agent.refine_code = AsyncMock(
-            return_value="print('Still Broken')"
-        )
-        
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        result = loop.run_until_complete(
-            self.agent.reproduce_from_paper(self.ctx, output_dir=self.test_dir)
-        )
-        
-        self.assertEqual(result.status, "failed")
-        self.assertEqual(result.retry_count, 1) # attempted 1 retry due to max_retries=1
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture
+def paper_context():
+    return PaperContext(
+        title="E2E Paper",
+        abstract="Abstract",
+        method_section="Method",
+    )
+
+
+@pytest.mark.asyncio
+async def test_happy_path_completes_without_retries(tmp_path, paper_context):
+    agent = _legacy_agent_with_common_nodes()
+    agent.verification_node.run = AsyncMock(
+        return_value=NodeResult.ok(_report(all_passed=True, syntax_ok=True, imports_ok=True))
+    )
+
+    result = await agent.reproduce_from_paper(paper_context, output_dir=tmp_path)
+
+    assert result.status is ReproPhase.COMPLETED
+    assert result.retry_count == 0
+    assert (tmp_path / "main.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_retry_path_records_repairs_and_still_completes(tmp_path, paper_context):
+    agent = _legacy_agent_with_common_nodes()
+    agent.verification_node.run = AsyncMock(
+        return_value=NodeResult.ok(
+            _report(
+                all_passed=False,
+                syntax_ok=True,
+                imports_ok=True,
+                errors=["SyntaxError: invalid syntax"],
+                repairs_attempted=1,
+            )
+        )
+    )
+
+    result = await agent.reproduce_from_paper(paper_context, output_dir=tmp_path)
+
+    assert result.status is ReproPhase.COMPLETED
+    assert result.retry_count == 1
+    assert result.verification["syntax_ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_failure_path_surfaces_verification_errors(tmp_path, paper_context):
+    agent = _legacy_agent_with_common_nodes()
+    agent.verification_node.run = AsyncMock(
+        return_value=NodeResult.ok(
+            _report(
+                all_passed=False,
+                syntax_ok=False,
+                imports_ok=False,
+                errors=["Fatal Error"],
+                repairs_attempted=1,
+            )
+        )
+    )
+
+    result = await agent.reproduce_from_paper(paper_context, output_dir=tmp_path)
+
+    assert result.status is ReproPhase.FAILED
+    assert result.retry_count == 1
+    assert "Fatal Error" in result.errors

--- a/tests/test_repro_models.py
+++ b/tests/test_repro_models.py
@@ -1,70 +1,89 @@
-import sys
-from unittest.mock import MagicMock
+"""Compatibility tests for repro model helpers."""
 
-# Mock dependencies before importing modules under test
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["claude_agent_sdk"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
+from __future__ import annotations
 
-import unittest
-from repro.models import PaperContext, ReproductionPlan, ImplementationSpec, VerificationResult, VerificationStep
+from repro import (
+    ImplementationSpec,
+    PaperContext,
+    ReproductionPlan,
+    ReproductionResult,
+    ReproPhase,
+    VerificationResult,
+    VerificationStep,
+)
 
-class TestReproModels(unittest.TestCase):
-    def test_paper_context_to_prompt(self):
-        ctx = PaperContext(
-            title="Test Paper",
-            abstract="This is an abstract.",
-            method_section="Method details.",
-            algorithm_blocks=["Block 1"],
-            hyperparameters={"lr": 0.01}
-        )
-        prompt = ctx.to_prompt_context()
-        self.assertIn("## Paper: Test Paper", prompt)
-        self.assertIn("This is an abstract.", prompt)
-        self.assertIn("Method details.", prompt)
-        self.assertIn("Block 1", prompt)
-        self.assertIn("'lr': 0.01", prompt)
 
-    def test_reproduction_plan_to_prompt(self):
-        plan = ReproductionPlan(
-            project_name="test_proj",
-            description="A test project",
-            file_structure={"main.py": "entry"},
-            entry_point="main.py",
-            dependencies=["numpy"],
-            key_components=["Model"]
-        )
-        prompt = plan.to_prompt_context()
-        self.assertIn("## Reproduction Plan: test_proj", prompt)
-        self.assertIn("A test project", prompt)
-        self.assertIn("`main.py`: entry", prompt)
-        self.assertIn("Entry Point", prompt)
-        self.assertIn("numpy", prompt)
+def test_paper_context_to_prompt_contains_sections():
+    context = PaperContext(
+        title="Test Paper",
+        abstract="This is an abstract.",
+        method_section="Method details.",
+        algorithm_blocks=["Block 1"],
+        hyperparameters={"lr": 0.01},
+    )
 
-    def test_implementation_spec_to_prompt(self):
-        spec = ImplementationSpec(
-            model_type="transformer",
-            layers=[{"type": "Linear"}],
-            optimizer="adam"
-        )
-        prompt = spec.to_prompt_context()
-        self.assertIn("Model Type:** transformer", prompt)
-        self.assertIn("Optimizer:** adam", prompt)
-        self.assertIn("Linear", prompt)
+    prompt = context.to_prompt_context()
 
-    def test_verification_result_to_dict(self):
-        res = VerificationResult(
-            step=VerificationStep.SYNTAX_CHECK,
-            passed=True,
-            message="All good",
-            duration_sec=1.5
-        )
-        d = res.to_dict()
-        self.assertEqual(d["step"], "syntax_check")
-        self.assertTrue(d["passed"])
-        self.assertEqual(d["message"], "All good")
-        self.assertEqual(d["duration_sec"], 1.5)
+    assert "## Paper: Test Paper" in prompt
+    assert "This is an abstract." in prompt
+    assert "Method details." in prompt
+    assert "Block 1" in prompt
+    assert "'lr': 0.01" in prompt
 
-if __name__ == "__main__":
-    unittest.main()
+
+def test_reproduction_plan_to_prompt_context_lists_files():
+    plan = ReproductionPlan(
+        project_name="test_proj",
+        description="A test project",
+        file_structure={"main.py": "entry"},
+        entry_point="main.py",
+        dependencies=["numpy"],
+        key_components=["Model"],
+    )
+
+    prompt = plan.to_prompt_context()
+
+    assert "## Reproduction Plan: test_proj" in prompt
+    assert "`main.py`: entry" in prompt
+    assert "numpy" in prompt
+
+
+def test_implementation_spec_to_prompt_context_includes_optimizer():
+    spec = ImplementationSpec(
+        model_type="transformer",
+        layers=[{"type": "Linear"}],
+        optimizer="adam",
+    )
+
+    prompt = spec.to_prompt_context()
+
+    assert "Model Type:** transformer" in prompt
+    assert "Optimizer:** adam" in prompt
+    assert "Linear" in prompt
+
+
+def test_verification_result_and_reproduction_result_to_dict():
+    verification = VerificationResult(
+        step=VerificationStep.SYNTAX_CHECK,
+        passed=True,
+        message="All good",
+        duration_sec=1.5,
+    )
+    result = ReproductionResult(
+        paper_title="Test Paper",
+        status=ReproPhase.COMPLETED,
+        phases_completed=["planning"],
+        generated_files={"main.py": "# code"},
+        retry_count=1,
+    )
+    result.verification_results = [verification]
+    result.compute_score()
+
+    verification_payload = verification.to_dict()
+    result_payload = result.to_dict()
+
+    assert verification_payload["step"] == "syntax_check"
+    assert verification_payload["passed"] is True
+    assert result_payload["status"] == "completed"
+    assert result_payload["retry_count"] == 1
+    assert result_payload["generated_files"] == ["main.py"]

--- a/tests/test_repro_planning.py
+++ b/tests/test_repro_planning.py
@@ -1,60 +1,86 @@
-import sys
-from unittest.mock import MagicMock, patch
+"""Compatibility tests for the current repro planning layer."""
 
-# Mock dependencies before importing modules under test
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["claude_agent_sdk"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
+from __future__ import annotations
 
-import unittest
-from repro.planning_agent import PlanningAgent
-from repro.models import PaperContext, ReproductionPlan, ImplementationSpec
+import pytest
 
-class TestPlanningAgent(unittest.TestCase):
-    def setUp(self):
-        with patch('repro.planning_agent.query', None):
-            self.agent = PlanningAgent()
-        self.ctx = PaperContext(
-            title="Test Paper",
-            abstract="Abstract",
-            method_section="Method"
-        )
+from repro import Blueprint, PaperContext, PlanningNode, ReproductionPlan
 
-    def test_fallback_plan(self):
-        # Test fallback logic when LLM is mocked/unavailable
-        with patch('repro.planning_agent.query', None):
-            plan = self.agent._fallback_plan(self.ctx)
-            self.assertIsInstance(plan, ReproductionPlan)
-            self.assertEqual(plan.entry_point, "main.py")
-            self.assertIn("main.py", plan.file_structure)
 
-    def test_fallback_spec(self):
-        with patch('repro.planning_agent.query', None):
-            spec = self.agent._fallback_spec()
-            self.assertIsInstance(spec, ImplementationSpec)
-            self.assertEqual(spec.optimizer, "adam")
-    
-    def test_parse_plan_json(self):
-        json_str = """
-        {
-            "project_name": "test",
-            "description": "desc",
-            "file_structure": {"main.py": "entry"},
-            "entry_point": "main.py",
-            "dependencies": ["torch"],
-            "key_components": ["Model"],
-            "estimated_complexity": "low"
-        }
-        """
-        plan = self.agent._parse_plan(json_str, self.ctx)
-        self.assertEqual(plan.project_name, "test")
-        self.assertEqual(plan.dependencies, ["torch"])
+@pytest.fixture
+def paper_context():
+    return PaperContext(
+        title="Test Paper",
+        abstract="Abstract",
+        method_section="Method",
+    )
 
-    def test_parse_plan_invalid(self):
-        # Should return fallback on invalid JSON
-        plan = self.agent._parse_plan("invalid json", self.ctx)
-        self.assertEqual(plan.description, f"Reproduction of: {self.ctx.title}")
 
-if __name__ == "__main__":
-    unittest.main()
+def test_fallback_plan_without_blueprint_uses_default_files(paper_context):
+    node = PlanningNode()
+
+    plan = node._fallback_plan(paper_context)
+
+    assert isinstance(plan, ReproductionPlan)
+    assert plan.entry_point == "main.py"
+    assert "main.py" in plan.file_structure
+    assert "torch" in plan.dependencies
+
+
+def test_fallback_plan_with_blueprint_infers_structure_and_dependencies(paper_context):
+    node = PlanningNode()
+    blueprint = Blueprint(
+        architecture_type="transformer",
+        module_hierarchy={"model": ["encoder", "decoder"], "trainer": []},
+        optimization_strategy="Adam with warmup",
+        loss_functions=["cross_entropy"],
+        input_output_spec={"input": "tokens"},
+        framework_hints=["pytorch", "transformers"],
+    )
+
+    plan = node._fallback_plan(paper_context, blueprint)
+
+    assert "model.py" in plan.file_structure
+    assert "trainer.py" in plan.file_structure
+    assert "losses.py" in plan.file_structure
+    assert "torch" in plan.dependencies
+    assert "transformers" in plan.dependencies
+
+
+def test_parse_plan_json_enriches_dependencies_from_blueprint_hints(paper_context):
+    node = PlanningNode()
+    blueprint = Blueprint(framework_hints=["pytorch", "transformers"])
+    response = """
+    {
+        "files": [{"path": "main.py", "purpose": "Entry point"}],
+        "components": ["Model"],
+        "dependencies": ["numpy"]
+    }
+    """
+
+    plan = node._parse_plan(response, paper_context, blueprint)
+
+    assert plan.project_name == "Test Paper"
+    assert plan.file_structure == {"main.py": "Entry point"}
+    assert "numpy" in plan.dependencies
+    assert "torch" in plan.dependencies
+    assert "transformers" in plan.dependencies
+
+
+def test_parse_plan_invalid_json_returns_fallback(paper_context):
+    node = PlanningNode()
+
+    plan = node._parse_plan("invalid json", paper_context)
+
+    assert plan.description == "Abstract"
+
+
+@pytest.mark.asyncio
+async def test_planning_node_run_uses_fallback_when_no_llm_is_available(paper_context):
+    node = PlanningNode()
+
+    result = await node.run(paper_context)
+
+    assert result.success is True
+    assert isinstance(result.data, ReproductionPlan)
+    assert "main.py" in result.data.file_structure

--- a/tests/unit/repro/test_agents.py
+++ b/tests/unit/repro/test_agents.py
@@ -1,76 +1,17 @@
-# tests/unit/repro/test_agents.py
-"""
-Unit tests for repro agents module.
-"""
+"""Unit tests for repro agents."""
 
-import sys
-from unittest.mock import MagicMock, patch, AsyncMock
+from __future__ import annotations
 
-# Mock external dependencies
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
-
-import unittest
-import asyncio
 from pathlib import Path
-from repro.agents.base_agent import BaseAgent, AgentResult, AgentStatus
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from repro.agents.base_agent import AgentResult, AgentStatus, BaseAgent
 from repro.agents.verification_agent import VerificationAgent, VerificationReport
 
 
-class TestAgentStatus(unittest.TestCase):
-    """Tests for AgentStatus enum."""
-
-    def test_status_values(self):
-        self.assertEqual(AgentStatus.IDLE.value, "idle")
-        self.assertEqual(AgentStatus.RUNNING.value, "running")
-        self.assertEqual(AgentStatus.COMPLETED.value, "completed")
-        self.assertEqual(AgentStatus.FAILED.value, "failed")
-        self.assertEqual(AgentStatus.WAITING.value, "waiting")
-
-
-class TestAgentResult(unittest.TestCase):
-    """Tests for AgentResult dataclass."""
-
-    def test_success_result(self):
-        result = AgentResult.success(data={"key": "value"}, metadata={"step": 1})
-
-        self.assertEqual(result.status, AgentStatus.COMPLETED)
-        self.assertEqual(result.data, {"key": "value"})
-        self.assertIsNone(result.error)
-        self.assertEqual(result.metadata, {"step": 1})
-
-    def test_failure_result(self):
-        result = AgentResult.failure("Something went wrong")
-
-        self.assertEqual(result.status, AgentStatus.FAILED)
-        self.assertIsNone(result.data)
-        self.assertEqual(result.error, "Something went wrong")
-
-    def test_to_dict(self):
-        result = AgentResult(
-            status=AgentStatus.COMPLETED,
-            data={"result": 42},
-            error=None,
-            duration_seconds=1.5,
-            messages=["Step 1 done", "Step 2 done"],
-            metadata={"info": "test"},
-        )
-
-        d = result.to_dict()
-
-        self.assertEqual(d["status"], "completed")
-        # data is converted to string
-        self.assertIn("42", d["data"])
-        self.assertIsNone(d["error"])
-        self.assertEqual(d["duration_seconds"], 1.5)
-        self.assertEqual(len(d["messages"]), 2)
-        self.assertEqual(d["metadata"]["info"], "test")
-
-
 class ConcreteAgent(BaseAgent):
-    """Concrete implementation for testing."""
-
     def __init__(self, return_value=None, should_fail=False, **kwargs):
         super().__init__(name="TestAgent", **kwargs)
         self.return_value = return_value
@@ -84,172 +25,190 @@ class ConcreteAgent(BaseAgent):
         return AgentResult.success(data=self.return_value)
 
 
-class TestBaseAgent(unittest.TestCase):
-    """Tests for BaseAgent class."""
-
-    def test_agent_creation(self):
-        agent = ConcreteAgent(max_retries=3)
-
-        self.assertEqual(agent.name, "TestAgent")
-        self.assertEqual(agent.max_retries, 3)
-        self.assertEqual(agent.status, AgentStatus.IDLE)
-
-    def test_successful_run(self):
-        agent = ConcreteAgent(return_value={"answer": 42})
-
-        result = asyncio.run(agent.run({}))
-
-        self.assertEqual(result.status, AgentStatus.COMPLETED)
-        self.assertEqual(result.data, {"answer": 42})
-        self.assertEqual(agent.execute_count, 1)
-
-    def test_failed_run(self):
-        agent = ConcreteAgent(should_fail=True)
-
-        result = asyncio.run(agent.run({}))
-
-        self.assertEqual(result.status, AgentStatus.FAILED)
-        self.assertIn("Test error", result.error)
-
-    def test_status_tracking(self):
-        agent = ConcreteAgent()
-
-        self.assertEqual(agent.status, AgentStatus.IDLE)
-
-        # Run should update status
-        asyncio.run(agent.run({}))
-
-        self.assertEqual(agent.status, AgentStatus.COMPLETED)
-
-    def test_duration_tracking(self):
-        agent = ConcreteAgent()
-
-        result = asyncio.run(agent.run({}))
-
-        self.assertGreaterEqual(result.duration_seconds, 0)
-
-    def test_log_method(self):
-        agent = ConcreteAgent()
-
-        agent.log("Test message")
-
-        self.assertEqual(len(agent._messages), 1)
-        self.assertIn("Test message", agent._messages[0])
+def test_agent_status_values():
+    assert AgentStatus.IDLE.value == "idle"
+    assert AgentStatus.RUNNING.value == "running"
+    assert AgentStatus.COMPLETED.value == "completed"
+    assert AgentStatus.FAILED.value == "failed"
+    assert AgentStatus.WAITING.value == "waiting"
 
 
-class TestVerificationReport(unittest.TestCase):
-    """Tests for VerificationReport dataclass."""
+def test_agent_result_success():
+    result = AgentResult.success(data={"key": "value"}, metadata={"step": 1})
 
-    def test_all_passed_true(self):
-        report = VerificationReport(
-            syntax_ok=True,
-            imports_ok=True,
-            tests_ok=False,
-            smoke_ok=False,
-        )
-
-        self.assertTrue(report.all_passed)
-        self.assertFalse(report.fully_passed)
-
-    def test_all_passed_false(self):
-        report = VerificationReport(
-            syntax_ok=True,
-            imports_ok=False,
-        )
-
-        self.assertFalse(report.all_passed)
-
-    def test_fully_passed(self):
-        report = VerificationReport(
-            syntax_ok=True,
-            imports_ok=True,
-            tests_ok=True,
-            smoke_ok=True,
-        )
-
-        self.assertTrue(report.fully_passed)
-
-    def test_to_dict(self):
-        report = VerificationReport(
-            syntax_ok=True,
-            imports_ok=True,
-            errors=["Error 1"],
-            warnings=["Warning 1"],
-        )
-
-        d = report.to_dict()
-
-        self.assertTrue(d["syntax_ok"])
-        self.assertTrue(d["imports_ok"])
-        self.assertTrue(d["all_passed"])
-        self.assertFalse(d["fully_passed"])
-        self.assertEqual(d["errors"], ["Error 1"])
-        self.assertEqual(d["warnings"], ["Warning 1"])
+    assert result.status is AgentStatus.COMPLETED
+    assert result.data == {"key": "value"}
+    assert result.error is None
+    assert result.metadata == {"step": 1}
 
 
-class TestVerificationAgent(unittest.TestCase):
-    """Tests for VerificationAgent class."""
+def test_agent_result_failure():
+    result = AgentResult.failure("Something went wrong")
 
-    def setUp(self):
-        self.agent = VerificationAgent(timeout=10, run_tests=False, run_smoke=False)
-
-    def test_missing_output_dir(self):
-        result = asyncio.run(self.agent.run({}))
-
-        self.assertEqual(result.status, AgentStatus.FAILED)
-        self.assertIn("output_dir", result.error)
-
-    def test_nonexistent_output_dir(self):
-        result = asyncio.run(self.agent.run({"output_dir": "/nonexistent/path"}))
-
-        self.assertEqual(result.status, AgentStatus.FAILED)
-        self.assertIn("does not exist", result.error)
-
-    def test_syntax_check_valid(self):
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Write valid Python
-            (Path(tmpdir) / "test.py").write_text("def hello(): pass")
-
-            result = asyncio.run(self.agent.run({"output_dir": tmpdir}))
-
-            self.assertEqual(result.status, AgentStatus.COMPLETED)
-            self.assertTrue(result.data["report"].syntax_ok)
-
-    def test_syntax_check_invalid(self):
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Write invalid Python
-            (Path(tmpdir) / "broken.py").write_text("def broken(")
-
-            result = asyncio.run(self.agent.run({"output_dir": tmpdir}))
-
-            self.assertEqual(result.status, AgentStatus.COMPLETED)
-            self.assertFalse(result.data["report"].syntax_ok)
-            self.assertGreater(len(result.data["report"].errors), 0)
-
-    def test_import_check(self):
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Write a simple module
-            (Path(tmpdir) / "simple.py").write_text("x = 1")
-
-            result = asyncio.run(self.agent.run({"output_dir": tmpdir}))
-
-            self.assertEqual(result.status, AgentStatus.COMPLETED)
-            self.assertTrue(result.data["report"].imports_ok)
-
-    def test_context_updated_with_report(self):
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            (Path(tmpdir) / "test.py").write_text("x = 1")
-
-            context = {"output_dir": tmpdir}
-            asyncio.run(self.agent.run(context))
-
-            self.assertIn("verification_report", context)
-            self.assertIsInstance(context["verification_report"], VerificationReport)
+    assert result.status is AgentStatus.FAILED
+    assert result.data is None
+    assert result.error == "Something went wrong"
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_agent_result_to_dict():
+    result = AgentResult(
+        status=AgentStatus.COMPLETED,
+        data={"result": 42},
+        error=None,
+        duration_seconds=1.5,
+        messages=["Step 1 done", "Step 2 done"],
+        metadata={"info": "test"},
+    )
+
+    payload = result.to_dict()
+
+    assert payload["status"] == "completed"
+    assert "42" in payload["data"]
+    assert payload["error"] is None
+    assert payload["duration_seconds"] == 1.5
+    assert len(payload["messages"]) == 2
+    assert payload["metadata"]["info"] == "test"
+
+
+@pytest.mark.asyncio
+async def test_base_agent_successful_run():
+    agent = ConcreteAgent(return_value={"answer": 42})
+
+    result = await agent.run({})
+
+    assert result.status is AgentStatus.COMPLETED
+    assert result.data == {"answer": 42}
+    assert agent.execute_count == 1
+
+
+@pytest.mark.asyncio
+async def test_base_agent_failed_run():
+    agent = ConcreteAgent(should_fail=True)
+
+    result = await agent.run({})
+
+    assert result.status is AgentStatus.FAILED
+    assert "Test error" in result.error
+
+
+@pytest.mark.asyncio
+async def test_base_agent_status_tracking():
+    agent = ConcreteAgent()
+
+    assert agent.status is AgentStatus.IDLE
+    await agent.run({})
+    assert agent.status is AgentStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_base_agent_duration_tracking():
+    agent = ConcreteAgent()
+
+    result = await agent.run({})
+
+    assert result.duration_seconds >= 0
+
+
+def test_base_agent_log_method():
+    agent = ConcreteAgent()
+
+    agent.log("Test message")
+
+    assert len(agent._messages) == 1
+    assert "Test message" in agent._messages[0]
+
+
+def test_verification_report_properties():
+    partial = VerificationReport(syntax_ok=True, imports_ok=True, tests_ok=False, smoke_ok=False)
+    failed = VerificationReport(syntax_ok=True, imports_ok=False)
+    complete = VerificationReport(syntax_ok=True, imports_ok=True, tests_ok=True, smoke_ok=True)
+
+    assert partial.all_passed is True
+    assert partial.fully_passed is False
+    assert failed.all_passed is False
+    assert complete.fully_passed is True
+
+
+def test_verification_report_to_dict():
+    report = VerificationReport(
+        syntax_ok=True,
+        imports_ok=True,
+        errors=["Error 1"],
+        warnings=["Warning 1"],
+    )
+
+    payload = report.to_dict()
+
+    assert payload["syntax_ok"] is True
+    assert payload["imports_ok"] is True
+    assert payload["all_passed"] is True
+    assert payload["fully_passed"] is False
+    assert payload["errors"] == ["Error 1"]
+    assert payload["warnings"] == ["Warning 1"]
+
+
+@pytest.fixture
+def verification_agent():
+    return VerificationAgent(timeout=10, run_tests=False, run_smoke=False)
+
+
+@pytest.mark.asyncio
+async def test_verification_agent_missing_output_dir(verification_agent):
+    result = await verification_agent.run({})
+
+    assert result.status is AgentStatus.FAILED
+    assert "output_dir" in result.error
+
+
+@pytest.mark.asyncio
+async def test_verification_agent_nonexistent_output_dir(verification_agent):
+    result = await verification_agent.run({"output_dir": "/nonexistent/path"})
+
+    assert result.status is AgentStatus.FAILED
+    assert "does not exist" in result.error
+
+
+@pytest.mark.asyncio
+async def test_verification_agent_syntax_check_valid(verification_agent):
+    with TemporaryDirectory() as tmpdir:
+        (Path(tmpdir) / "test.py").write_text("def hello(): pass", encoding="utf-8")
+
+        result = await verification_agent.run({"output_dir": tmpdir})
+
+    assert result.status is AgentStatus.COMPLETED
+    assert result.data["report"].syntax_ok is True
+
+
+@pytest.mark.asyncio
+async def test_verification_agent_syntax_check_invalid(verification_agent):
+    with TemporaryDirectory() as tmpdir:
+        (Path(tmpdir) / "broken.py").write_text("def broken(", encoding="utf-8")
+
+        result = await verification_agent.run({"output_dir": tmpdir})
+
+    assert result.status is AgentStatus.COMPLETED
+    assert result.data["report"].syntax_ok is False
+    assert result.data["report"].errors
+
+
+@pytest.mark.asyncio
+async def test_verification_agent_import_check(verification_agent):
+    with TemporaryDirectory() as tmpdir:
+        (Path(tmpdir) / "simple.py").write_text("x = 1", encoding="utf-8")
+
+        result = await verification_agent.run({"output_dir": tmpdir})
+
+    assert result.status is AgentStatus.COMPLETED
+    assert result.data["report"].imports_ok is True
+
+
+@pytest.mark.asyncio
+async def test_verification_agent_updates_context_with_report(verification_agent):
+    with TemporaryDirectory() as tmpdir:
+        (Path(tmpdir) / "test.py").write_text("x = 1", encoding="utf-8")
+        context = {"output_dir": tmpdir}
+
+        await verification_agent.run(context)
+
+    assert "verification_report" in context
+    assert isinstance(context["verification_report"], VerificationReport)

--- a/tests/unit/repro/test_blueprint.py
+++ b/tests/unit/repro/test_blueprint.py
@@ -1,269 +1,166 @@
-# tests/unit/repro/test_blueprint.py
-"""
-Unit tests for Blueprint and related models.
-"""
+"""Pytest coverage for repro data models and blueprint helpers."""
 
-import sys
-from unittest.mock import MagicMock
+from __future__ import annotations
 
-# Mock external dependencies
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
-
-import unittest
-from repro.models import (
-    Blueprint,
+from repro import (
     AlgorithmSpec,
+    Blueprint,
+    EnvironmentSpec,
+    ImplementationSpec,
     PaperContext,
     ReproductionPlan,
-    ImplementationSpec,
-    EnvironmentSpec,
     ReproductionResult,
     ReproPhase,
+    VerificationResult,
+    VerificationStep,
 )
 
 
-class TestAlgorithmSpec(unittest.TestCase):
-    """Tests for AlgorithmSpec dataclass."""
+def test_algorithm_spec_defaults():
+    spec = AlgorithmSpec(name="Attention", inputs=["query", "key"], outputs=["value"])
 
-    def test_creation(self):
-        spec = AlgorithmSpec(
-            name="Attention",
-            pseudocode="1. Compute Q, K, V\n2. Apply softmax",
-            inputs=["query", "key", "value"],
-            outputs=["attention_output"],
-        )
-
-        self.assertEqual(spec.name, "Attention")
-        self.assertEqual(len(spec.inputs), 3)
-        self.assertEqual(len(spec.outputs), 1)
+    assert spec.name == "Attention"
+    assert spec.complexity == ""
+    assert spec.inputs == ["query", "key"]
+    assert spec.outputs == ["value"]
 
 
-class TestBlueprint(unittest.TestCase):
-    """Tests for Blueprint dataclass."""
+def test_blueprint_to_compressed_context_includes_high_signal_sections():
+    blueprint = Blueprint(
+        architecture_type="transformer",
+        module_hierarchy={"model": ["encoder", "decoder"]},
+        key_hyperparameters={"d_model": 512, "n_heads": 8},
+        loss_functions=["cross_entropy"],
+        framework_hints=["pytorch"],
+        paper_title="Attention Is All You Need",
+        paper_year=2017,
+        domain="nlp",
+    )
 
-    def test_creation_minimal(self):
-        blueprint = Blueprint(
-            architecture_type="transformer",
-            domain="nlp",
-        )
+    context = blueprint.to_compressed_context()
 
-        self.assertEqual(blueprint.architecture_type, "transformer")
-        self.assertEqual(blueprint.domain, "nlp")
-
-    def test_creation_full(self):
-        algo = AlgorithmSpec(
-            name="Attention",
-            pseudocode="Attention mechanism",
-            inputs=["Q", "K", "V"],
-            outputs=["out"],
-        )
-
-        blueprint = Blueprint(
-            architecture_type="transformer",
-            domain="nlp",
-            core_algorithms=[algo],
-            key_hyperparameters={"d_model": 512, "n_heads": 8},
-            loss_functions=["cross_entropy"],
-            optimization_strategy="Adam with warmup",
-            framework_hints=["pytorch"],
-        )
-
-        self.assertEqual(len(blueprint.core_algorithms), 1)
-        self.assertEqual(blueprint.key_hyperparameters["d_model"], 512)
-        self.assertIn("pytorch", blueprint.framework_hints)
-
-    def test_to_compressed_context(self):
-        blueprint = Blueprint(
-            architecture_type="transformer",
-            domain="nlp",
-            key_hyperparameters={"d_model": 512},
-            loss_functions=["cross_entropy"],
-        )
-
-        context = blueprint.to_compressed_context()
-
-        self.assertIn("transformer", context)
-        self.assertIn("nlp", context)
-        self.assertIn("d_model", context)
+    assert "Attention Is All You Need" in context
+    assert "transformer" in context
+    assert "encoder" in context
+    assert "d_model" in context
+    assert "cross_entropy" in context
 
 
-class TestPaperContext(unittest.TestCase):
-    """Tests for PaperContext dataclass."""
+def test_blueprint_round_trips_through_dict_serialization():
+    original = Blueprint(
+        architecture_type="gnn",
+        module_hierarchy={"model": ["message_passing"]},
+        data_flow=[("input", "encoder")],
+        core_algorithms=[AlgorithmSpec(name="MessagePassing", pseudocode="aggregate")],
+        key_hyperparameters={"hidden_dim": 128},
+        input_output_spec={"input": "graph", "output": "logits"},
+        framework_hints=["pytorch"],
+        paper_title="Graph Networks",
+        paper_year=2020,
+        domain="cv",
+    )
 
-    def test_minimal_creation(self):
-        ctx = PaperContext(
-            title="Test Paper",
-            abstract="This is a test.",
-        )
+    restored = Blueprint.from_dict(original.to_dict())
 
-        self.assertEqual(ctx.title, "Test Paper")
-        self.assertEqual(ctx.abstract, "This is a test.")
-
-    def test_full_creation(self):
-        ctx = PaperContext(
-            title="Attention Is All You Need",
-            abstract="We propose a new architecture...",
-            method_section="The Transformer model...",
-            algorithm_blocks=["Algorithm 1: Attention"],
-            hyperparameters={"d_model": 512, "n_heads": 8},
-        )
-
-        self.assertEqual(len(ctx.algorithm_blocks), 1)
-        self.assertEqual(ctx.hyperparameters["d_model"], 512)
-
-    def test_to_prompt_context(self):
-        ctx = PaperContext(
-            title="Test Paper",
-            abstract="Abstract text here.",
-            method_section="Method details.",
-            hyperparameters={"lr": 0.001},
-        )
-
-        prompt = ctx.to_prompt_context()
-
-        self.assertIn("## Paper: Test Paper", prompt)
-        self.assertIn("Abstract text here", prompt)
-        self.assertIn("Method details", prompt)
-        self.assertIn("lr", prompt)
+    assert restored.architecture_type == "gnn"
+    assert restored.module_hierarchy == {"model": ["message_passing"]}
+    assert restored.core_algorithms[0].name == "MessagePassing"
+    assert restored.input_output_spec["output"] == "logits"
 
 
-class TestReproductionPlan(unittest.TestCase):
-    """Tests for ReproductionPlan dataclass."""
+def test_paper_context_to_prompt_context_renders_sections():
+    context = PaperContext(
+        title="Test Paper",
+        abstract="This is an abstract.",
+        method_section="Method details.",
+        algorithm_blocks=["for step in range(n): pass"],
+        hyperparameters={"lr": 0.01},
+    )
 
-    def test_creation(self):
-        plan = ReproductionPlan(
-            project_name="my_project",
-            description="A test project",
-            file_structure={"main.py": "entry", "model.py": "model"},
-            entry_point="main.py",
-            dependencies=["torch", "numpy"],
-            key_components=["Model", "Trainer"],
-        )
+    prompt = context.to_prompt_context()
 
-        self.assertEqual(plan.project_name, "my_project")
-        self.assertEqual(len(plan.file_structure), 2)
-        self.assertIn("torch", plan.dependencies)
-
-    def test_to_prompt_context(self):
-        plan = ReproductionPlan(
-            project_name="test_proj",
-            description="Test description",
-            file_structure={"main.py": "entry point"},
-            entry_point="main.py",
-            dependencies=["numpy"],
-            key_components=["Model"],
-        )
-
-        prompt = plan.to_prompt_context()
-
-        self.assertIn("test_proj", prompt)
-        self.assertIn("main.py", prompt)
-        self.assertIn("numpy", prompt)
+    assert "## Paper: Test Paper" in prompt
+    assert "This is an abstract." in prompt
+    assert "Method details." in prompt
+    assert "for step in range(n): pass" in prompt
+    assert "'lr': 0.01" in prompt
 
 
-class TestImplementationSpec(unittest.TestCase):
-    """Tests for ImplementationSpec dataclass."""
+def test_reproduction_plan_to_prompt_context_lists_files_and_dependencies():
+    plan = ReproductionPlan(
+        project_name="test_proj",
+        description="A test project",
+        file_structure={"main.py": "entry point", "model.py": "model code"},
+        entry_point="main.py",
+        dependencies=["numpy", "torch"],
+        key_components=["Model", "Trainer"],
+    )
 
-    def test_creation(self):
-        spec = ImplementationSpec(
-            model_type="transformer",
-            layers=[{"type": "Linear", "in": 512, "out": 512}],
-            optimizer="adam",
-            learning_rate=0.001,
-            batch_size=32,
-        )
+    prompt = plan.to_prompt_context()
 
-        self.assertEqual(spec.model_type, "transformer")
-        self.assertEqual(len(spec.layers), 1)
-        self.assertEqual(spec.learning_rate, 0.001)
-
-    def test_to_prompt_context(self):
-        spec = ImplementationSpec(
-            model_type="cnn",
-            optimizer="sgd",
-            batch_size=64,
-        )
-
-        prompt = spec.to_prompt_context()
-
-        self.assertIn("cnn", prompt)
-        self.assertIn("sgd", prompt)
+    assert "test_proj" in prompt
+    assert "`main.py`: entry point" in prompt
+    assert "torch" in prompt
+    assert "Trainer" in prompt
 
 
-class TestEnvironmentSpec(unittest.TestCase):
-    """Tests for EnvironmentSpec dataclass."""
+def test_implementation_spec_to_prompt_context_includes_layers_and_optimizer():
+    spec = ImplementationSpec(
+        model_type="transformer",
+        layers=[{"type": "Linear", "in": 512, "out": 512}],
+        optimizer="adamw",
+        learning_rate=3e-4,
+        batch_size=16,
+    )
 
-    def test_defaults(self):
-        spec = EnvironmentSpec()
+    prompt = spec.to_prompt_context()
 
-        self.assertEqual(spec.python_version, "3.10")
-        self.assertEqual(spec.base_image, "python:3.10-slim")
-
-    def test_generate_dockerfile(self):
-        spec = EnvironmentSpec(
-            python_version="3.9",
-            pip_requirements=["torch", "numpy"],
-        )
-
-        dockerfile = spec.generate_dockerfile()
-
-        self.assertIn("FROM python", dockerfile)
-        self.assertIn("pip install", dockerfile)
+    assert "transformer" in prompt
+    assert "adamw" in prompt
+    assert "Linear" in prompt
+    assert "Batch Size" in prompt
 
 
-class TestReproductionResult(unittest.TestCase):
-    """Tests for ReproductionResult dataclass."""
+def test_environment_spec_generates_dockerfile_and_conda_yaml():
+    spec = EnvironmentSpec(
+        python_version="3.9",
+        pytorch_version="2.2.0",
+        pip_requirements=["numpy", "pytest"],
+    )
 
-    def test_default_values(self):
-        result = ReproductionResult(paper_title="Test Paper")
+    dockerfile = spec.generate_dockerfile()
+    conda_yaml = spec.generate_conda_yaml()
 
-        self.assertEqual(result.paper_title, "Test Paper")
-        self.assertEqual(result.status, ReproPhase.PLANNING)
-        self.assertEqual(result.phases_completed, [])
-        self.assertEqual(result.generated_files, {})
-
-    def test_compute_score_with_results(self):
-        from repro.models import VerificationResult, VerificationStep
-
-        result = ReproductionResult(
-            paper_title="Test",
-            status=ReproPhase.COMPLETED,
-        )
-        result.verification_results = [
-            VerificationResult(step=VerificationStep.SYNTAX_CHECK, passed=True, message="OK"),
-            VerificationResult(step=VerificationStep.IMPORT_CHECK, passed=True, message="OK"),
-        ]
-
-        score = result.compute_score()
-        self.assertGreater(score, 0)
-
-    def test_compute_score_empty(self):
-        result = ReproductionResult(
-            paper_title="Test",
-            status=ReproPhase.FAILED,
-        )
-
-        score = result.compute_score()
-        self.assertEqual(score, 0)
-
-    def test_to_dict(self):
-        result = ReproductionResult(
-            paper_title="Test Paper",
-            status=ReproPhase.COMPLETED,
-            phases_completed=["planning"],
-            generated_files={"main.py": "# code"},
-            retry_count=1,
-        )
-
-        d = result.to_dict()
-
-        self.assertEqual(d["paper_title"], "Test Paper")
-        self.assertEqual(d["status"], "completed")
-        self.assertIn("planning", d["phases_completed"])
-        self.assertEqual(d["retry_count"], 1)
+    assert dockerfile.startswith("FROM ")
+    assert "pip install -r requirements.txt" in dockerfile
+    assert "python=3.9" in conda_yaml
+    assert "numpy" in conda_yaml
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_reproduction_result_compute_score_and_to_dict():
+    result = ReproductionResult(
+        paper_title="Test Paper",
+        status=ReproPhase.COMPLETED,
+        generated_files={"main.py": "print('hi')"},
+        phases_completed=["planning", "generation"],
+        retry_count=1,
+    )
+    result.verification_results = [
+        VerificationResult(step=VerificationStep.SYNTAX_CHECK, passed=True, message="OK"),
+        VerificationResult(step=VerificationStep.IMPORT_CHECK, passed=True, message="OK"),
+    ]
+
+    score = result.compute_score()
+    payload = result.to_dict()
+
+    assert score == 50
+    assert payload["paper_title"] == "Test Paper"
+    assert payload["status"] == "completed"
+    assert payload["generated_files"] == ["main.py"]
+    assert payload["retry_count"] == 1
+
+
+def test_reproduction_result_score_is_zero_without_verification():
+    result = ReproductionResult(paper_title="Test Paper", status=ReproPhase.FAILED)
+
+    assert result.compute_score() == 0

--- a/tests/unit/repro/test_memory.py
+++ b/tests/unit/repro/test_memory.py
@@ -1,373 +1,159 @@
-# tests/unit/repro/test_memory.py
-"""
-Unit tests for CodeMemory and SymbolIndex modules.
-"""
+"""Pytest coverage for repro code memory primitives."""
 
-import sys
-from unittest.mock import MagicMock
+from __future__ import annotations
 
-# Mock external dependencies
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
-
-import unittest
-from repro.memory.symbol_index import SymbolIndex, SymbolInfo
 from repro.memory.code_memory import CodeMemory, FileInfo
+from repro.memory.symbol_index import SymbolIndex, SymbolInfo
 
 
-class TestSymbolInfo(unittest.TestCase):
-    """Tests for SymbolInfo dataclass."""
+def test_symbol_info_to_summary_variants():
+    class_info = SymbolInfo(
+        name="MyClass",
+        kind="class",
+        file="model.py",
+        line=10,
+        signature="(BaseModel)",
+    )
+    function_info = SymbolInfo(
+        name="train",
+        kind="function",
+        file="trainer.py",
+        line=20,
+        signature="(model, data, epochs: int)",
+    )
+    variable_info = SymbolInfo(
+        name="LEARNING_RATE",
+        kind="variable",
+        file="config.py",
+        line=1,
+    )
 
-    def test_to_summary_class(self):
-        info = SymbolInfo(
-            name="MyClass",
-            kind="class",
-            file="model.py",
-            line=10,
-            signature="(BaseModel)",
-        )
-        summary = info.to_summary()
-        self.assertEqual(summary, "class MyClass(BaseModel)")
-
-    def test_to_summary_function(self):
-        info = SymbolInfo(
-            name="train",
-            kind="function",
-            file="trainer.py",
-            line=5,
-            signature="(model, data, epochs: int)",
-        )
-        summary = info.to_summary()
-        self.assertEqual(summary, "def train(model, data, epochs: int)")
-
-    def test_to_summary_variable(self):
-        info = SymbolInfo(
-            name="LEARNING_RATE",
-            kind="variable",
-            file="config.py",
-            line=1,
-        )
-        summary = info.to_summary()
-        self.assertEqual(summary, "LEARNING_RATE: variable")
+    assert class_info.to_summary() == "class MyClass(BaseModel)"
+    assert function_info.to_summary() == "def train(model, data, epochs: int)"
+    assert variable_info.to_summary() == "LEARNING_RATE: variable"
 
 
-class TestSymbolIndex(unittest.TestCase):
-    """Tests for SymbolIndex class."""
-
-    def setUp(self):
-        self.index = SymbolIndex()
-
-    def test_index_simple_function(self):
-        code = '''
-def hello(name: str) -> str:
-    """Say hello."""
-    return f"Hello, {name}"
-'''
-        symbols = self.index.index_file("utils.py", code)
-
-        self.assertEqual(len(symbols), 1)
-        self.assertEqual(symbols[0].name, "hello")
-        self.assertEqual(symbols[0].kind, "function")
-        self.assertIn("name: str", symbols[0].signature)
-        self.assertEqual(symbols[0].docstring, "Say hello.")
-
-    def test_index_class(self):
-        code = '''
-class Model(nn.Module):
-    """A neural network model."""
-
-    def __init__(self, hidden_size: int):
-        super().__init__()
-        self.fc = nn.Linear(hidden_size, hidden_size)
-
-    def forward(self, x):
-        return self.fc(x)
-'''
-        symbols = self.index.index_file("model.py", code)
-
-        # Should find the class
-        class_symbols = [s for s in symbols if s.kind == "class"]
-        self.assertEqual(len(class_symbols), 1)
-        self.assertEqual(class_symbols[0].name, "Model")
-        self.assertIn("nn.Module", class_symbols[0].signature)
-        self.assertEqual(class_symbols[0].docstring, "A neural network model.")
-
-    def test_index_async_function(self):
-        code = '''
-async def fetch_data(url: str) -> dict:
-    """Fetch data asynchronously."""
-    pass
-'''
-        symbols = self.index.index_file("api.py", code)
-
-        self.assertEqual(len(symbols), 1)
-        self.assertEqual(symbols[0].kind, "async_function")
-        self.assertEqual(symbols[0].name, "fetch_data")
-
-    def test_index_module_variables(self):
-        code = '''
-MAX_SIZE = 1024
-DEFAULT_NAME = "model"
-'''
-        symbols = self.index.index_file("constants.py", code)
-
-        var_symbols = [s for s in symbols if s.kind == "variable"]
-        self.assertEqual(len(var_symbols), 2)
-        names = {s.name for s in var_symbols}
-        self.assertIn("MAX_SIZE", names)
-        self.assertIn("DEFAULT_NAME", names)
-
-    def test_index_imports(self):
-        code = '''
+def test_symbol_index_extracts_symbols_docstrings_and_imports():
+    code = """
 import torch
 from torch import nn
-from typing import List, Optional
-'''
-        symbols = self.index.index_file("imports.py", code)
-
-        import_symbols = [s for s in symbols if s.kind == "import"]
-        self.assertTrue(len(import_symbols) >= 2)
-
-    def test_get_symbol(self):
-        code = "def my_func(): pass"
-        self.index.index_file("test.py", code)
-
-        symbol = self.index.get_symbol("my_func")
-        self.assertIsNotNone(symbol)
-        self.assertEqual(symbol.name, "my_func")
-
-    def test_get_file_symbols(self):
-        code = '''
-def func1(): pass
-def func2(): pass
-class MyClass: pass
-'''
-        self.index.index_file("multi.py", code)
-
-        symbols = self.index.get_file_symbols("multi.py")
-        names = {s.name for s in symbols}
-        self.assertIn("func1", names)
-        self.assertIn("func2", names)
-        self.assertIn("MyClass", names)
-
-    def test_find_dependents(self):
-        code1 = "def helper(): pass"
-        code2 = '''
-def main():
-    helper()
-'''
-        self.index.index_file("utils.py", code1)
-        self.index.index_file("main.py", code2)
-
-        dependents = self.index.find_dependents("helper")
-        self.assertIn("main", dependents)
-
-    def test_get_interface_summary(self):
-        code = '''
-class Model:
-    """The main model."""
-    pass
-
-def train(model):
-    """Train the model."""
-    pass
-'''
-        self.index.index_file("model.py", code)
-
-        summary = self.index.get_interface_summary("model.py")
-        self.assertIn("model.py", summary)
-        self.assertIn("class Model", summary)
-        self.assertIn("def train", summary)
-
-    def test_clear_file(self):
-        code = "def func(): pass"
-        self.index.index_file("temp.py", code)
-
-        self.assertIsNotNone(self.index.get_symbol("func"))
-
-        self.index.clear_file("temp.py")
-
-        self.assertIsNone(self.index.get_symbol("func"))
-
-    def test_syntax_error_handling(self):
-        invalid_code = "def broken("
-        symbols = self.index.index_file("broken.py", invalid_code)
-
-        # Should handle gracefully and return empty list
-        self.assertEqual(symbols, [])
-
-    def test_to_dict(self):
-        code = "def func(): pass"
-        self.index.index_file("test.py", code)
-
-        data = self.index.to_dict()
-        self.assertIn("symbols", data)
-        self.assertIn("file_symbols", data)
-        self.assertIn("func", data["symbols"])
-
 
-class TestCodeMemory(unittest.TestCase):
-    """Tests for CodeMemory class."""
-
-    def setUp(self):
-        self.memory = CodeMemory(max_context_tokens=1000)
+class Model(nn.Module):
+    \"\"\"A neural network model.\"\"\"
 
-    def test_add_file(self):
-        code = "print('hello')"
-        self.memory.add_file("main.py", code, purpose="Entry point")
+    def forward(self, x):
+        return x
 
-        self.assertEqual(self.memory.file_count, 1)
-        self.assertEqual(self.memory.get_file("main.py"), code)
 
-    def test_files_property(self):
-        self.memory.add_file("a.py", "# a")
-        self.memory.add_file("b.py", "# b")
+async def fetch_data(url: str) -> dict:
+    \"\"\"Fetch data asynchronously.\"\"\"
+    return {}
+"""
+    index = SymbolIndex()
 
-        files = self.memory.files
-        self.assertEqual(len(files), 2)
-        self.assertEqual(files["a.py"], "# a")
-        self.assertEqual(files["b.py"], "# b")
+    symbols = index.index_file("model.py", code)
 
-    def test_extract_imports(self):
-        config_code = "CONFIG = {}"
-        model_code = '''
-from config import CONFIG
+    class_symbols = [symbol for symbol in symbols if symbol.kind == "class"]
+    async_symbols = [symbol for symbol in symbols if symbol.kind == "async_function"]
+    import_symbols = [symbol for symbol in symbols if symbol.kind == "import"]
 
-class Model:
-    pass
-'''
-        self.memory.add_file("config.py", config_code)
-        self.memory.add_file("model.py", model_code)
+    assert class_symbols[0].name == "Model"
+    assert class_symbols[0].docstring == "A neural network model."
+    assert async_symbols[0].name == "fetch_data"
+    assert len(import_symbols) >= 2
 
-        # Check dependencies were detected
-        deps = self.memory._files["model.py"].dependencies
-        self.assertIn("config.py", deps)
 
-    def test_compute_generation_order(self):
-        file_structure = {
-            "main.py": "entry",
-            "model.py": "model",
-            "config.py": "config",
-            "utils.py": "utils",
-            "data.py": "data",
-        }
+def test_symbol_index_handles_syntax_errors_gracefully():
+    index = SymbolIndex()
 
-        order = self.memory.compute_generation_order(file_structure)
+    assert index.index_file("broken.py", "def broken(") == []
 
-        # Config should come before model
-        config_idx = order.index("config.py")
-        model_idx = order.index("model.py")
-        main_idx = order.index("main.py")
 
-        self.assertLess(config_idx, model_idx)
-        self.assertLess(model_idx, main_idx)
+def test_symbol_index_tracks_file_symbols_and_dependents():
+    index = SymbolIndex()
+    index.index_file("utils.py", "def helper():\n    pass\n")
+    index.index_file("main.py", "def main():\n    helper()\n")
 
-    def test_get_relevant_context(self):
-        self.memory.add_file("config.py", "LR = 0.001", purpose="Configuration")
-        self.memory.add_file("model.py", "class Model: pass", purpose="Model definition")
+    file_symbols = {symbol.name for symbol in index.get_file_symbols("utils.py")}
+    dependents = index.find_dependents("helper")
 
-        context = self.memory.get_relevant_context("trainer.py", "Training logic")
+    assert "helper" in file_symbols
+    assert "main" in dependents
+    assert index.get_symbol("helper") is not None
 
-        # Should include config and model as dependencies
-        self.assertIn("config.py", context)
 
-    def test_get_interface_summary(self):
-        self.memory.add_file("model.py", "class Model: pass")
-        self.memory.add_file("data.py", "def load_data(): pass")
+def test_code_memory_tracks_files_and_dependencies():
+    memory = CodeMemory(max_context_tokens=1000)
+    memory.add_file("config.py", "CONFIG = {}", purpose="Configuration")
+    memory.add_file(
+        "model.py",
+        "from config import CONFIG\n\nclass Model:\n    pass\n",
+        purpose="Model definition",
+    )
 
-        summary = self.memory.get_interface_summary()
+    assert memory.file_count == 2
+    assert memory.get_file("config.py") == "CONFIG = {}"
+    assert memory.files["model.py"].startswith("from config import CONFIG")
+    assert "config.py" in memory._files["model.py"].dependencies
 
-        self.assertIn("class Model", summary)
-        self.assertIn("def load_data", summary)
 
-    def test_get_symbol_definition(self):
-        code = '''
-def my_function(x, y):
-    """Add two numbers."""
-    return x + y
+def test_code_memory_computes_generation_order_from_dependencies():
+    memory = CodeMemory()
+    file_structure = {
+        "main.py": "entry",
+        "trainer.py": "training logic",
+        "model.py": "model",
+        "config.py": "configuration",
+        "data.py": "data loading",
+    }
 
-def other():
-    pass
-'''
-        self.memory.add_file("math.py", code)
+    order = memory.compute_generation_order(file_structure)
 
-        definition = self.memory.get_symbol_definition("my_function")
+    assert order.index("config.py") < order.index("model.py")
+    assert order.index("model.py") < order.index("trainer.py")
+    assert order.index("main.py") == len(order) - 1
 
-        self.assertIn("def my_function", definition)
-        self.assertIn("return x + y", definition)
 
-    def test_get_dependency_graph(self):
-        self.memory.add_file("config.py", "X = 1")
-        self.memory.add_file("model.py", "from config import X")
+def test_code_memory_relevant_context_and_interface_summary_include_known_files():
+    memory = CodeMemory(max_context_tokens=1000)
+    memory.add_file("config.py", "LR = 0.001", purpose="Configuration")
+    memory.add_file("model.py", "class Model:\n    pass\n", purpose="Model definition")
+    memory.add_file("data.py", "def load_data():\n    pass\n", purpose="Data loading")
 
-        graph = self.memory.get_dependency_graph()
+    context = memory.get_relevant_context("trainer.py", "Training logic")
+    summary = memory.get_interface_summary()
 
-        self.assertIn("config.py", graph)
-        self.assertIn("model.py", graph)
+    assert "config.py" in context
+    assert "class Model" in summary
+    assert "def load_data" in summary
 
-    def test_clear(self):
-        self.memory.add_file("a.py", "# a")
-        self.memory.add_file("b.py", "# b")
 
-        self.assertEqual(self.memory.file_count, 2)
+def test_code_memory_serialization_and_clear_reset_state():
+    memory = CodeMemory(max_context_tokens=200)
+    large_content = "x = 1\n" * 100
+    memory.add_file("large.py", large_content, purpose="Large file")
 
-        self.memory.clear()
+    context = memory.get_relevant_context("test.py", "test")
+    payload = memory.to_dict()
 
-        self.assertEqual(self.memory.file_count, 0)
+    assert len(context) < len(large_content)
+    assert "large.py" in payload["files"]
+    assert "symbol_index" in payload
 
-    def test_to_dict(self):
-        self.memory.add_file("test.py", "# test", purpose="Test file")
+    memory.clear()
 
-        data = self.memory.to_dict()
+    assert memory.file_count == 0
 
-        self.assertIn("files", data)
-        self.assertIn("generation_order", data)
-        self.assertIn("symbol_index", data)
-        self.assertIn("test.py", data["files"])
-        self.assertEqual(data["files"]["test.py"]["purpose"], "Test file")
 
-    def test_predict_dependencies(self):
-        self.memory.add_file("config.py", "# config")
-        self.memory.add_file("model.py", "# model")
-        self.memory.add_file("data.py", "# data")
+def test_file_info_defaults():
+    file_info = FileInfo(
+        path="model.py",
+        content="class Model: pass",
+        purpose="Model definition",
+        generation_order=0,
+    )
 
-        deps = self.memory._predict_dependencies("trainer.py")
-
-        self.assertIn("config.py", deps)
-        self.assertIn("model.py", deps)
-        self.assertIn("data.py", deps)
-
-    def test_token_budget_respected(self):
-        # Create a memory with small token budget
-        memory = CodeMemory(max_context_tokens=50)  # ~200 chars
-
-        # Add a large file
-        large_content = "x = 1\n" * 100  # Much larger than budget
-        memory.add_file("large.py", large_content)
-
-        context = memory.get_relevant_context("test.py", "test")
-
-        # Context should be truncated
-        self.assertLess(len(context), len(large_content))
-
-
-class TestFileInfo(unittest.TestCase):
-    """Tests for FileInfo dataclass."""
-
-    def test_file_info_creation(self):
-        info = FileInfo(
-            path="model.py",
-            content="class Model: pass",
-            purpose="Model definition",
-            generation_order=0,
-        )
-
-        self.assertEqual(info.path, "model.py")
-        self.assertEqual(info.purpose, "Model definition")
-        self.assertEqual(info.dependencies, set())
-        self.assertEqual(info.dependents, set())
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert file_info.path == "model.py"
+    assert file_info.purpose == "Model definition"
+    assert file_info.dependencies == set()
+    assert file_info.dependents == set()

--- a/tests/unit/repro/test_orchestrator.py
+++ b/tests/unit/repro/test_orchestrator.py
@@ -1,268 +1,236 @@
-# tests/unit/repro/test_orchestrator.py
-"""
-Unit tests for Orchestrator module.
-"""
+"""Unit tests for the repro orchestrator."""
 
-import sys
-from unittest.mock import MagicMock, patch, AsyncMock
+from __future__ import annotations
 
-# Mock external dependencies
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
-
-import unittest
 import asyncio
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from repro.agents.base_agent import AgentResult, AgentStatus
+from repro.models import PaperContext, ReproPhase
 from repro.orchestrator import (
     Orchestrator,
     OrchestratorConfig,
+    ParallelOrchestrator,
     PipelineProgress,
     PipelineStage,
-    ParallelOrchestrator,
 )
-from repro.agents.base_agent import AgentResult, AgentStatus
-from repro.models import PaperContext, ReproPhase
 
 
-class TestOrchestratorConfig(unittest.TestCase):
-    """Tests for OrchestratorConfig dataclass."""
+def test_orchestrator_config_defaults():
+    config = OrchestratorConfig()
 
-    def test_default_values(self):
-        config = OrchestratorConfig()
-
-        self.assertEqual(config.max_repair_loops, 3)
-        self.assertTrue(config.parallel_agents)
-        self.assertEqual(config.timeout_seconds, 300)
-        self.assertIsNone(config.output_dir)
-        self.assertTrue(config.use_rag)
-        self.assertEqual(config.max_context_tokens, 8000)
-
-    def test_custom_values(self):
-        config = OrchestratorConfig(
-            max_repair_loops=5,
-            parallel_agents=False,
-            output_dir=Path("/tmp/test"),
-            use_rag=False,
-        )
-
-        self.assertEqual(config.max_repair_loops, 5)
-        self.assertFalse(config.parallel_agents)
-        self.assertEqual(config.output_dir, Path("/tmp/test"))
-        self.assertFalse(config.use_rag)
+    assert config.max_repair_loops == 3
+    assert config.parallel_agents is True
+    assert config.timeout_seconds == 300
+    assert config.output_dir is None
+    assert config.use_rag is True
+    assert config.max_context_tokens == 8000
 
 
-class TestPipelineStage(unittest.TestCase):
-    """Tests for PipelineStage enum."""
+def test_orchestrator_config_custom_values():
+    config = OrchestratorConfig(
+        max_repair_loops=5,
+        parallel_agents=False,
+        output_dir=Path("/tmp/test"),
+        use_rag=False,
+    )
 
-    def test_stage_values(self):
-        self.assertEqual(PipelineStage.PLANNING.value, "planning")
-        self.assertEqual(PipelineStage.CODING.value, "coding")
-        self.assertEqual(PipelineStage.VERIFICATION.value, "verification")
-        self.assertEqual(PipelineStage.DEBUGGING.value, "debugging")
-        self.assertEqual(PipelineStage.COMPLETED.value, "completed")
-        self.assertEqual(PipelineStage.FAILED.value, "failed")
-
-
-class TestPipelineProgress(unittest.TestCase):
-    """Tests for PipelineProgress dataclass."""
-
-    def test_default_values(self):
-        progress = PipelineProgress()
-
-        self.assertEqual(progress.current_stage, PipelineStage.PLANNING)
-        self.assertEqual(progress.stages_completed, [])
-        self.assertEqual(progress.repair_loop_count, 0)
-        self.assertEqual(progress.agent_results, {})
-
-    def test_duration_not_started(self):
-        progress = PipelineProgress()
-
-        self.assertEqual(progress.duration_seconds, 0.0)
-
-    def test_duration_in_progress(self):
-        progress = PipelineProgress()
-        progress.start_time = datetime.now()
-
-        # Should return positive duration
-        self.assertGreaterEqual(progress.duration_seconds, 0.0)
-
-    def test_duration_completed(self):
-        progress = PipelineProgress()
-        progress.start_time = datetime.now()
-        progress.end_time = datetime.now()
-
-        self.assertGreaterEqual(progress.duration_seconds, 0.0)
-
-    def test_to_dict(self):
-        progress = PipelineProgress(
-            current_stage=PipelineStage.CODING,
-            stages_completed=["planning"],
-            repair_loop_count=1,
-        )
-        progress.start_time = datetime.now()
-
-        d = progress.to_dict()
-
-        self.assertEqual(d["current_stage"], "coding")
-        self.assertEqual(d["stages_completed"], ["planning"])
-        self.assertEqual(d["repair_loop_count"], 1)
-        self.assertIn("duration_seconds", d)
+    assert config.max_repair_loops == 5
+    assert config.parallel_agents is False
+    assert config.output_dir == Path("/tmp/test")
+    assert config.use_rag is False
 
 
-class TestOrchestrator(unittest.TestCase):
-    """Tests for Orchestrator class."""
-
-    def setUp(self):
-        self.config = OrchestratorConfig(max_repair_loops=1)
-        self.orchestrator = Orchestrator(config=self.config)
-        self.paper_context = PaperContext(
-            title="Test Paper",
-            abstract="This is a test abstract for testing purposes.",
-        )
-
-    def test_initialization(self):
-        self.assertIsNotNone(self.orchestrator.planning_agent)
-        self.assertIsNotNone(self.orchestrator.coding_agent)
-        self.assertIsNotNone(self.orchestrator.verification_agent)
-        self.assertIsNotNone(self.orchestrator.debugging_agent)
-        self.assertEqual(self.orchestrator.context, {})
-
-    def test_progress_callback(self):
-        progress_updates = []
-
-        def on_progress(progress):
-            progress_updates.append(progress.current_stage)
-
-        orchestrator = Orchestrator(
-            config=self.config,
-            on_progress=on_progress,
-        )
-
-        # Mock agents to return quickly
-        orchestrator.planning_agent.run = AsyncMock(return_value=AgentResult.failure("Skip"))
-
-        asyncio.run(orchestrator.run(self.paper_context))
-
-        # Should have received at least one progress update
-        self.assertGreater(len(progress_updates), 0)
-
-    def test_run_planning_failure(self):
-        # Mock planning to fail
-        self.orchestrator.planning_agent.run = AsyncMock(
-            return_value=AgentResult.failure("Planning failed")
-        )
-
-        result = asyncio.run(self.orchestrator.run(self.paper_context))
-
-        self.assertEqual(result.status, ReproPhase.FAILED)
-        self.assertIn("Planning failed", result.error)
-
-    def test_run_coding_failure(self):
-        # Mock planning to succeed
-        self.orchestrator.planning_agent.run = AsyncMock(
-            return_value=AgentResult.success(data={"plan": {}})
-        )
-        # Mock coding to fail
-        self.orchestrator.coding_agent.run = AsyncMock(
-            return_value=AgentResult.failure("Coding failed")
-        )
-
-        result = asyncio.run(self.orchestrator.run(self.paper_context))
-
-        self.assertEqual(result.status, ReproPhase.FAILED)
-        self.assertIn("Coding failed", result.error)
-
-    def test_context_shared_between_agents(self):
-        # Mock planning to add to context
-        async def planning_run(context):
-            context["plan"] = {"files": ["main.py"]}
-            return AgentResult.success(data={"plan": context["plan"]})
-
-        async def coding_run(context):
-            # Should have access to plan
-            self.assertIn("plan", context)
-            return AgentResult.failure("Stop here")
-
-        self.orchestrator.planning_agent.run = planning_run
-        self.orchestrator.coding_agent.run = coding_run
-
-        asyncio.run(self.orchestrator.run(self.paper_context))
-
-        # Verify context was shared
-        self.assertIn("plan", self.orchestrator.context)
-
-    def test_result_includes_timing(self):
-        # Mock all agents to succeed quickly
-        self.orchestrator.planning_agent.run = AsyncMock(
-            return_value=AgentResult.success(data={})
-        )
-        self.orchestrator.coding_agent.run = AsyncMock(
-            return_value=AgentResult.success(data={"generated_files": {}})
-        )
-
-        # Mock verification to succeed
-        mock_report = MagicMock()
-        mock_report.all_passed = True
-        mock_report.to_dict.return_value = {}
-
-        async def verify_run(context):
-            context["verification_report"] = mock_report
-            return AgentResult.success(data={"report": mock_report})
-
-        self.orchestrator.verification_agent.run = verify_run
-
-        result = asyncio.run(self.orchestrator.run(self.paper_context))
-
-        self.assertIsNotNone(result.total_duration_sec)
-        self.assertGreaterEqual(result.total_duration_sec, 0)
-
-    def test_repair_loop_count(self):
-        # Mock planning and coding to succeed
-        self.orchestrator.planning_agent.run = AsyncMock(
-            return_value=AgentResult.success(data={})
-        )
-        self.orchestrator.coding_agent.run = AsyncMock(
-            return_value=AgentResult.success(data={"generated_files": {}})
-        )
-
-        # Mock verification to fail
-        mock_report = MagicMock()
-        mock_report.all_passed = False
-        mock_report.to_dict.return_value = {}
-
-        async def verify_run(context):
-            context["verification_report"] = mock_report
-            context["error"] = "Verification failed"
-            return AgentResult.success(data={"report": mock_report})
-
-        self.orchestrator.verification_agent.run = verify_run
-        self.orchestrator.debugging_agent.run = AsyncMock(
-            return_value=AgentResult.success(data={})
-        )
-
-        result = asyncio.run(self.orchestrator.run(self.paper_context))
-
-        # Should have attempted repairs
-        self.assertGreater(result.retry_count, 0)
+def test_pipeline_stage_values():
+    assert PipelineStage.PLANNING.value == "planning"
+    assert PipelineStage.CODING.value == "coding"
+    assert PipelineStage.VERIFICATION.value == "verification"
+    assert PipelineStage.DEBUGGING.value == "debugging"
+    assert PipelineStage.COMPLETED.value == "completed"
+    assert PipelineStage.FAILED.value == "failed"
 
 
-class TestParallelOrchestrator(unittest.TestCase):
-    """Tests for ParallelOrchestrator class."""
+def test_pipeline_progress_defaults():
+    progress = PipelineProgress()
 
-    def test_inherits_from_orchestrator(self):
-        orchestrator = ParallelOrchestrator()
-
-        self.assertIsInstance(orchestrator, Orchestrator)
-
-    def test_run_parallel_exists(self):
-        orchestrator = ParallelOrchestrator()
-
-        self.assertTrue(hasattr(orchestrator, "run_parallel"))
-        self.assertTrue(callable(orchestrator.run_parallel))
+    assert progress.current_stage is PipelineStage.PLANNING
+    assert progress.stages_completed == []
+    assert progress.repair_loop_count == 0
+    assert progress.agent_results == {}
+    assert progress.duration_seconds == 0.0
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_pipeline_progress_duration_and_dict():
+    progress = PipelineProgress(
+        current_stage=PipelineStage.CODING,
+        stages_completed=["planning"],
+        repair_loop_count=1,
+    )
+    progress.start_time = datetime.now()
+    progress.end_time = datetime.now()
+
+    payload = progress.to_dict()
+
+    assert payload["current_stage"] == "coding"
+    assert payload["stages_completed"] == ["planning"]
+    assert payload["repair_loop_count"] == 1
+    assert "duration_seconds" in payload
+
+
+@pytest.fixture
+def paper_context():
+    return PaperContext(
+        title="Test Paper",
+        abstract="This is a test abstract for testing purposes.",
+    )
+
+
+@pytest.fixture
+def orchestrator():
+    return Orchestrator(config=OrchestratorConfig(max_repair_loops=1))
+
+
+def test_orchestrator_initialization(orchestrator):
+    assert orchestrator.planning_agent is not None
+    assert orchestrator.coding_agent is not None
+    assert orchestrator.verification_agent is not None
+    assert orchestrator.debugging_agent is not None
+    assert orchestrator.context == {}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_progress_callback(paper_context):
+    progress_updates = []
+
+    def on_progress(progress):
+        progress_updates.append(progress.current_stage)
+
+    orchestrator = Orchestrator(config=OrchestratorConfig(max_repair_loops=1), on_progress=on_progress)
+    orchestrator.planning_agent.run = AsyncMock(return_value=AgentResult.failure("Skip"))
+
+    await orchestrator.run(paper_context)
+
+    assert progress_updates
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_run_planning_failure(orchestrator, paper_context):
+    orchestrator.planning_agent.run = AsyncMock(return_value=AgentResult.failure("Planning failed"))
+
+    result = await orchestrator.run(paper_context)
+
+    assert result.status is ReproPhase.FAILED
+    assert "Planning failed" in result.error
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_run_coding_failure(orchestrator, paper_context):
+    orchestrator.planning_agent.run = AsyncMock(return_value=AgentResult.success(data={"plan": {}}))
+    orchestrator.context["plan"] = {"files": []}
+    orchestrator.coding_agent.run = AsyncMock(return_value=AgentResult.failure("Coding failed"))
+
+    result = await orchestrator.run(paper_context)
+
+    assert result.status is ReproPhase.FAILED
+    assert "Coding failed" in result.error
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_context_shared_between_agents(orchestrator, paper_context):
+    async def planning_run(context):
+        context["plan"] = {"files": ["main.py"]}
+        return AgentResult.success(data={"plan": context["plan"]})
+
+    async def coding_run(context):
+        assert "plan" in context
+        context["generated_files"] = {"main.py": "print('hello')"}
+        return AgentResult.success(data={"generated_files": context["generated_files"]})
+
+    report = MagicMock()
+    report.all_passed = True
+    report.to_dict.return_value = {}
+
+    async def verification_run(context):
+        context["verification_report"] = report
+        return AgentResult.success(data={"report": report})
+
+    orchestrator.planning_agent.run = planning_run
+    orchestrator.coding_agent.run = coding_run
+    orchestrator.verification_agent.run = verification_run
+
+    result = await orchestrator.run(paper_context)
+
+    assert "plan" in orchestrator.context
+    assert result.status is ReproPhase.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_result_includes_timing(orchestrator, paper_context):
+    orchestrator.planning_agent.run = AsyncMock(return_value=AgentResult.success(data={}))
+    orchestrator.coding_agent.run = AsyncMock(return_value=AgentResult.success(data={"generated_files": {}}))
+
+    report = MagicMock()
+    report.all_passed = True
+    report.to_dict.return_value = {}
+
+    async def verify_run(context):
+        context["verification_report"] = report
+        return AgentResult.success(data={"report": report})
+
+    orchestrator.verification_agent.run = verify_run
+
+    result = await orchestrator.run(paper_context)
+
+    assert result.total_duration_sec is not None
+    assert result.total_duration_sec >= 0
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_repair_loop_count(orchestrator, paper_context):
+    orchestrator.planning_agent.run = AsyncMock(return_value=AgentResult.success(data={}))
+    orchestrator.coding_agent.run = AsyncMock(return_value=AgentResult.success(data={"generated_files": {}}))
+
+    report = MagicMock()
+    report.all_passed = False
+    report.to_dict.return_value = {}
+
+    async def verify_run(context):
+        context["verification_report"] = report
+        context["error"] = "Verification failed"
+        return AgentResult.success(data={"report": report})
+
+    orchestrator.verification_agent.run = verify_run
+    orchestrator.debugging_agent.run = AsyncMock(return_value=AgentResult.success(data={}))
+
+    result = await orchestrator.run(paper_context)
+
+    assert result.retry_count > 0
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_timeout_is_enforced(paper_context):
+    orchestrator = Orchestrator(config=OrchestratorConfig(timeout_seconds=0.01))
+
+    async def slow_planning(_context):
+        await asyncio.sleep(0.05)
+        return AgentResult.success(data={})
+
+    orchestrator.planning_agent.run = slow_planning
+
+    result = await orchestrator.run(paper_context)
+
+    assert result.status is ReproPhase.FAILED
+    assert result.error == "Pipeline timed out after 0.01s"
+    assert orchestrator.progress.current_stage is PipelineStage.FAILED
+
+
+def test_parallel_orchestrator_inherits_from_orchestrator():
+    parallel = ParallelOrchestrator()
+
+    assert isinstance(parallel, Orchestrator)
+    assert hasattr(parallel, "run_parallel")
+    assert callable(parallel.run_parallel)

--- a/tests/unit/repro/test_rag.py
+++ b/tests/unit/repro/test_rag.py
@@ -1,347 +1,105 @@
-# tests/unit/repro/test_rag.py
-"""
-Unit tests for CodeKnowledgeBase (RAG) module.
-"""
+"""Pytest coverage for repro RAG knowledge base."""
 
-import sys
-from unittest.mock import MagicMock
+from __future__ import annotations
 
-# Mock external dependencies
-sys.modules["docker"] = MagicMock()
-sys.modules["docker.errors"] = MagicMock()
-sys.modules["anthropic"] = MagicMock()
-
-import unittest
-from repro.rag.knowledge_base import CodeKnowledgeBase, CodePattern, BUILTIN_PATTERNS
+from repro.rag.knowledge_base import BUILTIN_PATTERNS, CodeKnowledgeBase, CodePattern
 
 
-class TestCodePattern(unittest.TestCase):
-    """Tests for CodePattern dataclass."""
+def test_code_pattern_to_context_renders_metadata_and_code():
+    pattern = CodePattern(
+        name="training_loop",
+        description="Training loop with validation",
+        code="for batch in loader:\n    pass",
+        tags=["training", "pytorch"],
+        source="unit test",
+    )
 
-    def test_pattern_creation(self):
-        pattern = CodePattern(
-            name="test_pattern",
-            description="A test pattern",
-            code="def test(): pass",
-            tags=["test", "unit"],
-            source="test suite",
-        )
+    context = pattern.to_context()
 
-        self.assertEqual(pattern.name, "test_pattern")
-        self.assertEqual(pattern.description, "A test pattern")
-        self.assertEqual(pattern.code, "def test(): pass")
-        self.assertEqual(pattern.tags, ["test", "unit"])
-        self.assertEqual(pattern.source, "test suite")
-        self.assertEqual(pattern.language, "python")  # default
-
-    def test_to_context(self):
-        pattern = CodePattern(
-            name="my_pattern",
-            description="Does something useful",
-            code="x = 1\ny = 2",
-            tags=["example"],
-        )
-
-        context = pattern.to_context()
-
-        self.assertIn("# Pattern: my_pattern", context)
-        self.assertIn("# Does something useful", context)
-        self.assertIn("x = 1", context)
-        self.assertIn("y = 2", context)
+    assert "# Pattern: training_loop" in context
+    assert "# Training loop with validation" in context
+    assert "for batch in loader" in context
 
 
-class TestCodeKnowledgeBase(unittest.TestCase):
-    """Tests for CodeKnowledgeBase class."""
+def test_knowledge_base_add_search_and_get_pattern():
+    kb = CodeKnowledgeBase()
+    pattern = CodePattern(
+        name="transformer_encoder",
+        description="Encoder block",
+        code="# encoder",
+        tags=["attention", "transformer"],
+    )
+    kb.add_pattern(pattern)
 
-    def setUp(self):
-        self.kb = CodeKnowledgeBase()
+    results = kb.search("transformer encoder", k=3)
 
-    def test_add_pattern(self):
-        pattern = CodePattern(
-            name="test",
-            description="Test",
-            code="# test",
-            tags=["testing"],
-        )
+    assert len(results) == 1
+    assert results[0].name == "transformer_encoder"
+    assert kb.get_pattern("transformer_encoder") is pattern
 
-        self.kb.add_pattern(pattern)
 
-        self.assertEqual(len(self.kb.patterns), 1)
-        self.assertIn("test", self.kb.patterns)
-
-    def test_search_by_tag(self):
-        pattern1 = CodePattern(
-            name="pytorch_model",
-            description="PyTorch model",
-            code="class Model: pass",
-            tags=["pytorch", "model", "deep learning"],
-        )
-        pattern2 = CodePattern(
-            name="tensorflow_model",
-            description="TensorFlow model",
-            code="class TFModel: pass",
-            tags=["tensorflow", "model", "deep learning"],
-        )
-
-        self.kb.add_pattern(pattern1)
-        self.kb.add_pattern(pattern2)
-
-        # Search for pytorch
-        results = self.kb.search("pytorch", k=3)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].name, "pytorch_model")
-
-        # Search for model (should find both)
-        results = self.kb.search("model", k=3)
-        self.assertEqual(len(results), 2)
-
-    def test_search_by_name(self):
-        pattern = CodePattern(
-            name="transformer_encoder",
-            description="Encoder block",
-            code="# encoder",
-            tags=["attention"],
-        )
-
-        self.kb.add_pattern(pattern)
-
-        results = self.kb.search("transformer encoder", k=3)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].name, "transformer_encoder")
-
-    def test_search_by_description(self):
-        pattern = CodePattern(
-            name="pattern1",
-            description="Training loop with validation",
-            code="# code",
-            tags=["training"],
-        )
-
-        self.kb.add_pattern(pattern)
-
-        results = self.kb.search("validation", k=3)
-        self.assertEqual(len(results), 1)
-
-    def test_search_scoring(self):
-        # Pattern with tag match should score higher than description match
-        pattern1 = CodePattern(
+def test_knowledge_base_search_is_case_insensitive_and_prefers_tag_matches():
+    kb = CodeKnowledgeBase()
+    kb.add_pattern(
+        CodePattern(
             name="high_score",
             description="Other description",
             code="# code",
             tags=["pytorch", "training"],
         )
-        pattern2 = CodePattern(
+    )
+    kb.add_pattern(
+        CodePattern(
             name="low_score",
             description="Something about pytorch training",
             code="# code",
             tags=["other"],
         )
+    )
 
-        self.kb.add_pattern(pattern1)
-        self.kb.add_pattern(pattern2)
+    upper_results = kb.search("PYTORCH", k=3)
+    ranked_results = kb.search("pytorch training", k=2)
 
-        results = self.kb.search("pytorch training", k=2)
+    assert len(upper_results) == 2
+    assert ranked_results[0].name == "high_score"
 
-        # Tag matches score higher
-        self.assertEqual(results[0].name, "high_score")
 
-    def test_search_limit_k(self):
-        for i in range(10):
-            pattern = CodePattern(
-                name=f"pattern_{i}",
-                description="Test pattern",
-                code="# code",
-                tags=["test"],
-            )
-            self.kb.add_pattern(pattern)
+def test_knowledge_base_lists_sorted_tags_and_patterns():
+    kb = CodeKnowledgeBase()
+    kb.add_pattern(CodePattern(name="p1", description="", code="", tags=["beta", "alpha"]))
+    kb.add_pattern(CodePattern(name="p2", description="", code="", tags=["gamma", "alpha"]))
 
-        results = self.kb.search("test", k=3)
-        self.assertEqual(len(results), 3)
+    assert kb.list_tags() == ["alpha", "beta", "gamma"]
+    assert kb.list_patterns() == ["p1", "p2"]
 
-    def test_search_no_results(self):
-        pattern = CodePattern(
-            name="pytorch",
-            description="PyTorch",
-            code="# code",
-            tags=["pytorch"],
-        )
-        self.kb.add_pattern(pattern)
 
-        results = self.kb.search("tensorflow java", k=3)
-        self.assertEqual(len(results), 0)
-
-    def test_get_by_tag(self):
-        pattern1 = CodePattern(
-            name="p1",
-            description="D1",
-            code="#",
-            tags=["common", "a"],
-        )
-        pattern2 = CodePattern(
-            name="p2",
-            description="D2",
-            code="#",
-            tags=["common", "b"],
-        )
-
-        self.kb.add_pattern(pattern1)
-        self.kb.add_pattern(pattern2)
-
-        results = self.kb.get_by_tag("common")
-        self.assertEqual(len(results), 2)
-
-        results = self.kb.get_by_tag("a")
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].name, "p1")
-
-    def test_get_pattern(self):
-        pattern = CodePattern(
-            name="my_pattern",
-            description="D",
-            code="#",
-            tags=[],
-        )
-        self.kb.add_pattern(pattern)
-
-        result = self.kb.get_pattern("my_pattern")
-        self.assertIsNotNone(result)
-        self.assertEqual(result.name, "my_pattern")
-
-        result = self.kb.get_pattern("nonexistent")
-        self.assertIsNone(result)
-
-    def test_list_tags(self):
-        pattern1 = CodePattern(name="p1", description="", code="", tags=["alpha", "beta"])
-        pattern2 = CodePattern(name="p2", description="", code="", tags=["gamma", "alpha"])
-
-        self.kb.add_pattern(pattern1)
-        self.kb.add_pattern(pattern2)
-
-        tags = self.kb.list_tags()
-
-        self.assertIn("alpha", tags)
-        self.assertIn("beta", tags)
-        self.assertIn("gamma", tags)
-        self.assertEqual(tags, sorted(tags))  # Should be sorted
-
-    def test_list_patterns(self):
-        for i in range(3):
-            pattern = CodePattern(name=f"p{i}", description="", code="", tags=[])
-            self.kb.add_pattern(pattern)
-
-        patterns = self.kb.list_patterns()
-
-        self.assertEqual(len(patterns), 3)
-        self.assertIn("p0", patterns)
-        self.assertIn("p1", patterns)
-        self.assertIn("p2", patterns)
-
-    def test_to_dict(self):
-        pattern = CodePattern(
+def test_knowledge_base_serialization_keeps_summary_fields():
+    kb = CodeKnowledgeBase()
+    kb.add_pattern(
+        CodePattern(
             name="test",
             description="Test pattern",
             code="x = 1",
             tags=["tag1", "tag2"],
             source="unit test",
         )
-        self.kb.add_pattern(pattern)
+    )
 
-        data = self.kb.to_dict()
+    payload = kb.to_dict()
 
-        self.assertIn("patterns", data)
-        self.assertIn("tag_index", data)
-        self.assertIn("test", data["patterns"])
-        self.assertEqual(data["patterns"]["test"]["description"], "Test pattern")
-        self.assertEqual(data["patterns"]["test"]["code_length"], 5)
-
-    def test_case_insensitive_search(self):
-        pattern = CodePattern(
-            name="PyTorch_Model",
-            description="A PYTORCH model",
-            code="#",
-            tags=["PyTorch", "MODEL"],
-        )
-        self.kb.add_pattern(pattern)
-
-        # All variations should work
-        results = self.kb.search("pytorch", k=3)
-        self.assertEqual(len(results), 1)
-
-        results = self.kb.search("PYTORCH", k=3)
-        self.assertEqual(len(results), 1)
-
-        results = self.kb.search("PyTorch", k=3)
-        self.assertEqual(len(results), 1)
+    assert payload["patterns"]["test"]["description"] == "Test pattern"
+    assert payload["patterns"]["test"]["code_length"] == 5
+    assert "tag_index" in payload
 
 
-class TestBuiltinPatterns(unittest.TestCase):
-    """Tests for built-in patterns."""
+def test_builtin_patterns_are_registered_and_compile():
+    kb = CodeKnowledgeBase.from_builtin()
 
-    def test_from_builtin(self):
-        kb = CodeKnowledgeBase.from_builtin()
+    assert len(kb.patterns) > 0
+    assert "pytorch_training_loop" in [pattern.name for pattern in kb.search("training loop", k=5)]
+    assert "transformer_encoder_block" in [
+        pattern.name for pattern in kb.search("transformer attention encoder", k=5)
+    ]
 
-        self.assertGreater(len(kb.patterns), 0)
-        self.assertGreater(len(kb.list_tags()), 0)
-
-    def test_builtin_patterns_valid(self):
-        # All built-in patterns should have required fields
-        for pattern in BUILTIN_PATTERNS:
-            self.assertTrue(pattern.name, "Pattern must have a name")
-            self.assertTrue(pattern.description, "Pattern must have a description")
-            self.assertTrue(pattern.code, "Pattern must have code")
-            self.assertTrue(pattern.tags, "Pattern must have tags")
-
-    def test_builtin_training_loop(self):
-        kb = CodeKnowledgeBase.from_builtin()
-
-        results = kb.search("pytorch training loop", k=3)
-
-        self.assertGreater(len(results), 0)
-        # Should find the training loop pattern
-        names = [r.name for r in results]
-        self.assertIn("pytorch_training_loop", names)
-
-    def test_builtin_transformer(self):
-        kb = CodeKnowledgeBase.from_builtin()
-
-        results = kb.search("transformer attention encoder", k=3)
-
-        self.assertGreater(len(results), 0)
-        names = [r.name for r in results]
-        self.assertIn("transformer_encoder_block", names)
-
-    def test_builtin_dataloader(self):
-        kb = CodeKnowledgeBase.from_builtin()
-
-        results = kb.search("dataset dataloader", k=3)
-
-        self.assertGreater(len(results), 0)
-
-    def test_builtin_config(self):
-        kb = CodeKnowledgeBase.from_builtin()
-
-        results = kb.search("config dataclass settings", k=3)
-
-        self.assertGreater(len(results), 0)
-
-    def test_builtin_checkpoint(self):
-        kb = CodeKnowledgeBase.from_builtin()
-
-        results = kb.search("checkpoint save load model", k=3)
-
-        self.assertGreater(len(results), 0)
-        names = [r.name for r in results]
-        self.assertIn("checkpoint_manager", names)
-
-    def test_builtin_patterns_have_valid_python(self):
-        """Verify all built-in pattern code is valid Python."""
-        for pattern in BUILTIN_PATTERNS:
-            try:
-                # Try to compile the code (syntax check)
-                compile(pattern.code, f"<{pattern.name}>", "exec")
-            except SyntaxError as e:
-                self.fail(f"Pattern {pattern.name} has invalid Python: {e}")
-
-
-if __name__ == "__main__":
-    unittest.main()
+    for pattern in BUILTIN_PATTERNS:
+        compile(pattern.code, f"<{pattern.name}>", "exec")

--- a/tests/unit/test_context_layers.py
+++ b/tests/unit/test_context_layers.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from paperbot.context_engine.engine import ContextEngine, ContextEngineConfig
+from paperbot.infrastructure.stores.memory_store import SqlAlchemyMemoryStore
+from paperbot.memory.schema import MemoryCandidate
 
 
 def _make_engine(*, memory_store=None, research_store=None, config=None):
@@ -25,12 +27,22 @@ def _make_engine(*, memory_store=None, research_store=None, config=None):
     rs.create_context_run.return_value = {"id": 1}
 
     # Default return values for memory_store methods.
-    ms.list_memories.return_value = [
-        {"id": 1, "content": "pref1", "confidence": 0.9, "created_at": "2025-01-01T00:00:00+00:00", "use_count": 0},
-    ]
-    ms.search_memories.return_value = []
-    ms.search_memories_batch.return_value = {}
-    ms.touch_usage.return_value = None
+    if hasattr(ms.list_memories, "return_value"):
+        ms.list_memories.return_value = [
+            {
+                "id": 1,
+                "content": "pref1",
+                "confidence": 0.9,
+                "created_at": "2025-01-01T00:00:00+00:00",
+                "use_count": 0,
+            },
+        ]
+    if hasattr(ms.search_memories, "return_value"):
+        ms.search_memories.return_value = []
+    if hasattr(ms.search_memories_batch, "return_value"):
+        ms.search_memories_batch.return_value = {}
+    if hasattr(ms.touch_usage, "return_value"):
+        ms.touch_usage.return_value = None
 
     config = config or ContextEngineConfig(offline=True, paper_limit=0)
     engine = ContextEngine(
@@ -168,7 +180,7 @@ class TestBuildContextPackLayers:
         assert expected_keys.issubset(set(result.keys()))
 
     @pytest.mark.asyncio
-    async def test_cross_track_batch_hits_touch_usage(self):
+    async def test_cross_track_batch_hits_do_not_manual_touch_usage(self):
         engine, rs, ms = _make_engine()
         rs.get_active_track.return_value = {"id": 1, "name": "main"}
         rs.list_tracks.return_value = [
@@ -188,7 +200,43 @@ class TestBuildContextPackLayers:
         )
 
         touch_calls = [call.kwargs for call in ms.touch_usage.call_args_list]
-        assert any(201 in kwargs.get("item_ids", []) for kwargs in touch_calls)
+        assert not any(201 in kwargs.get("item_ids", []) for kwargs in touch_calls)
+
+    @pytest.mark.asyncio
+    async def test_relevant_memory_search_chain_touches_usage_once(self, tmp_path):
+        store = SqlAlchemyMemoryStore(
+            db_url=f"sqlite:///{tmp_path / 'context_memory_usage.db'}",
+            auto_create_schema=True,
+        )
+        _, _, rows = store.add_memories(
+            user_id="u1",
+            memories=[
+                MemoryCandidate(
+                    kind="fact",
+                    content="transformer retrieval memory",
+                    confidence=0.9,
+                    scope_type="track",
+                    scope_id="1",
+                    tags=["transformer"],
+                    evidence={},
+                )
+            ],
+            actor_id="test",
+        )
+
+        engine, rs, _ = _make_engine(memory_store=store)
+        rs.get_track.return_value = {"id": 1, "name": "main"}
+
+        await engine.build_context_pack(
+            user_id="u1",
+            query="transformer",
+            track_id=1,
+        )
+
+        stored = store.get_items_by_ids(user_id="u1", item_ids=[rows[0].id])
+        assert len(stored) == 1
+        assert stored[0]["use_count"] == 1
+        assert stored[0]["last_used_at"] is not None
 
     @pytest.mark.asyncio
     async def test_context_token_guard_trims_when_budget_exceeded(self):

--- a/tests/unit/test_memory_batch_search.py
+++ b/tests/unit/test_memory_batch_search.py
@@ -202,3 +202,24 @@ class TestSearchMemoriesBatch:
         )
 
         assert captured["scope_ids"] == ["t1", "t2"]
+
+    def test_batch_search_auto_touches_hits_once(self, tmp_path):
+        store = _store_with_data(tmp_path)
+
+        results = store.search_memories_batch(
+            user_id="u1",
+            query="vision",
+            scope_ids=["t2"],
+            scope_type="track",
+        )
+
+        assert len(results["t2"]) == 1
+
+        items = store.list_memories(
+            user_id="u1",
+            scope_type="track",
+            scope_id="t2",
+            limit=10,
+        )
+        assert items[0]["use_count"] == 1
+        assert items[0]["last_used_at"] is not None

--- a/tests/unit/test_memory_decay.py
+++ b/tests/unit/test_memory_decay.py
@@ -12,6 +12,7 @@ from paperbot.infrastructure.stores.memory_store import (
     _apply_mmr_rerank,
     _decay_score,
     _is_evergreen_memory,
+    _memory_relevance_score,
     _to_decay_lambda,
 )
 from paperbot.memory.schema import MemoryCandidate
@@ -20,6 +21,8 @@ from paperbot.memory.schema import MemoryCandidate
 def _make_item(
     *,
     confidence: float = 0.8,
+    hybrid_score: float | None = None,
+    vec_score: float | None = None,
     created_at: str | None = None,
     use_count: int = 0,
     scope_type: str = "track",
@@ -28,7 +31,7 @@ def _make_item(
     now = datetime.now(timezone.utc)
     if created_at is None:
         created_at = now.isoformat()
-    return {
+    item = {
         "id": 1,
         "confidence": confidence,
         "created_at": created_at,
@@ -36,6 +39,11 @@ def _make_item(
         "scope_type": scope_type,
         "kind": kind,
     }
+    if hybrid_score is not None:
+        item["hybrid_score"] = hybrid_score
+    if vec_score is not None:
+        item["vec_score"] = vec_score
+    return item
 
 
 class TestToDecayLambda:
@@ -69,6 +77,13 @@ class TestEvergreenMemory:
 
 
 class TestDecayScore:
+    def test_prefers_hybrid_score_over_confidence(self):
+        now = datetime.now(timezone.utc)
+        item = _make_item(confidence=0.95, hybrid_score=0.25, created_at=now.isoformat())
+        assert _memory_relevance_score(item) == pytest.approx(0.25)
+        score = _decay_score(item, now=now)
+        assert score == pytest.approx(0.375, abs=0.01)
+
     def test_fresh_high_confidence_scores_high(self):
         now = datetime.now(timezone.utc)
         item = _make_item(confidence=0.9, created_at=now.isoformat(), use_count=5)
@@ -153,6 +168,28 @@ class TestApplyDecayRanking:
         assert results[0]["id"] == 1
         assert results[1]["id"] == 2
         assert "decay_score" in results[0]
+
+    def test_ranking_uses_hybrid_score_before_confidence(self):
+        now = datetime.now(timezone.utc)
+        high_confidence_low_relevance = _make_item(
+            confidence=0.95,
+            hybrid_score=0.2,
+            created_at=now.isoformat(),
+        )
+        high_confidence_low_relevance["id"] = 1
+        lower_confidence_high_relevance = _make_item(
+            confidence=0.6,
+            hybrid_score=0.8,
+            created_at=now.isoformat(),
+        )
+        lower_confidence_high_relevance["id"] = 2
+
+        results = _apply_decay_ranking(
+            [high_confidence_low_relevance, lower_confidence_high_relevance],
+            now=now,
+        )
+
+        assert [item["id"] for item in results] == [2, 1]
 
     def test_empty_list_returns_empty(self):
         assert _apply_decay_ranking([]) == []

--- a/tests/unit/test_workflow_coordinator.py
+++ b/tests/unit/test_workflow_coordinator.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from paperbot.core.workflow_coordinator import ScholarWorkflowCoordinator
+
+
+class _FakeEventLog:
+    def __init__(self):
+        self.events = []
+
+    def append(self, event):
+        self.events.append(event)
+
+
+class _FakeInfluence:
+    def __init__(self, total=77.0, academic=70.0, engineering=84.0, momentum=12.0):
+        self.total_score = total
+        self.academic_score = academic
+        self.engineering_score = engineering
+        self.metrics_breakdown = {"academic": {"momentum_score": momentum}}
+
+
+@pytest.mark.asyncio
+async def test_workflow_coordinator_publishes_all_four_stage_scores(tmp_path):
+    coordinator = ScholarWorkflowCoordinator({"output_dir": str(tmp_path), "enable_fail_fast": False})
+    coordinator._research_agent = SimpleNamespace(process=AsyncMock(return_value={"venue_tier": 1}))
+    coordinator._code_analysis_agent = SimpleNamespace(
+        process=AsyncMock(return_value={"health_score": 91.0, "is_empty_repo": False})
+    )
+    coordinator._quality_agent = SimpleNamespace(
+        process=AsyncMock(return_value={"quality_scores": {"repo": {"overall_score": 0.82}}})
+    )
+    coordinator._influence_calculator = SimpleNamespace(calculate=lambda paper, code_meta: _FakeInfluence())
+    coordinator._report_writer = None
+
+    paper = SimpleNamespace(
+        paper_id="paper-1",
+        title="Test Paper",
+        abstract="Abstract",
+        citation_count=120,
+        github_url="https://github.com/example/repo",
+        has_code=True,
+    )
+    event_log = _FakeEventLog()
+
+    report_path, influence, pipeline = await coordinator.run_paper_pipeline(
+        paper,
+        event_log=event_log,
+        run_id="run-1",
+        trace_id="trace-1",
+    )
+
+    assert report_path is None
+    assert influence.total_score == 77.0
+    assert pipeline["status"] == "success"
+
+    score_events = [event for event in event_log.events if event.type == "score_update"]
+    assert [event.stage for event in score_events] == ["research", "code", "quality", "influence"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_coordinator_early_exit_skips_remaining_stages(tmp_path):
+    coordinator = ScholarWorkflowCoordinator(
+        {
+            "output_dir": str(tmp_path),
+            "enable_fail_fast": True,
+            "fail_fast": {"early_exit_threshold": 10.0},
+        }
+    )
+    coordinator._research_agent = SimpleNamespace(process=AsyncMock(return_value={}))
+    coordinator._code_analysis_agent = SimpleNamespace(process=AsyncMock())
+    coordinator._quality_agent = SimpleNamespace(process=AsyncMock())
+    coordinator._influence_calculator = SimpleNamespace(calculate=AsyncMock())
+    coordinator._report_writer = None
+
+    paper = SimpleNamespace(
+        paper_id="paper-low",
+        title="Low Impact Paper",
+        abstract="Abstract",
+        citation_count=0,
+        github_url="https://github.com/example/repo",
+        has_code=True,
+    )
+
+    report_path, influence, pipeline = await coordinator.run_paper_pipeline(paper)
+
+    assert report_path is None
+    assert influence.total_score == 0.0
+    assert pipeline["status"] == "success"
+    assert pipeline["stages"]["code"]["status"] == "skipped"
+    assert pipeline["stages"]["quality"]["status"] == "skipped"
+    assert pipeline["stages"]["influence"]["status"] == "skipped"
+    assert pipeline["stages"]["report"]["status"] == "skipped"
+    coordinator._code_analysis_agent.process.assert_not_awaited()
+    coordinator._quality_agent.process.assert_not_awaited()


### PR DESCRIPTION
## Summary
- land the repro and memory correctness fixes as a standalone follow-up on current `dev`
- carry the workflow coordinator and fail-fast wiring changes together with the updated repro test suite
- keep the branch focused on correctness regressions and test modernization

## Validation
- `pytest tests/unit/test_workflow_coordinator.py tests/unit/test_context_layers.py -q`
- `git diff --cached --check`
