### PR TITLE
fix(ci): remove invalid Vercel preview flag

### DIFF
--- a/.github/workflows/vercel-auto-deploy.yml
+++ b/.github/workflows/vercel-auto-deploy.yml
@@ -19,4 +19,5 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}          # Vercel 访问令牌
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}        # Vercel 组织 ID
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}# Vercel 项目 ID
-          vercel-args: '--preview'                          # dev 分支走预览部署 (CLI 默认也是预览)
+          # Preview is the default deploy mode for `vercel` unless `--prod` is passed.
+          # Recent Vercel CLI versions reject `--preview` as an unknown flag.


### PR DESCRIPTION
## Summary
- remove the `--preview` CLI argument from the Vercel auto-deploy workflow
- keep `dev` deployments in preview mode by relying on the Vercel CLI default behavior
- document in the workflow why the flag is omitted

## Why
Recent Vercel CLI versions reject `--preview` as an unknown option. Preview deployment is already the default unless `--prod` is passed, so the explicit flag breaks CI without changing behavior.

## Validation
- inspected the workflow from `origin/dev`
- verified the edited YAML and `git diff --check`
