### PR TITLE
fix(ci): keep Vercel secrets free of inline comments

### DIFF
--- a/.github/workflows/vercel-auto-deploy.yml
+++ b/.github/workflows/vercel-auto-deploy.yml
@@ -16,8 +16,11 @@ jobs:
       - name: Deploy to Vercel (preview)
         uses: amondnet/vercel-action@v20
         with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}          # Vercel 访问令牌
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}        # Vercel 组织 ID
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}# Vercel 项目 ID
+          # Vercel 访问令牌
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          # Vercel 组织 ID
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          # Vercel 项目 ID
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           # Preview is the default deploy mode for `vercel` unless `--prod` is passed.
           # Recent Vercel CLI versions reject `--preview` as an unknown flag.


### PR DESCRIPTION
## Summary
- move the Vercel secret comments onto standalone YAML lines
- keep the `vercel-token`, `vercel-org-id`, and `vercel-project-id` values free of comment suffixes
- preserve the current repo-secret-based deploy model for shared collaboration on `dev`

## Why
The current workflow passes `vercel-project-id` as `${{ secrets.VERCEL_PROJECT_ID }}# ...`, so the inline comment is concatenated into the value and Vercel reports `Project not found`.

This fix keeps the deployment fully automated through repository secrets, so collaborators do not need to run local Vercel auth for normal `dev` deploys.

## Validation
- inspected the live `origin/dev` workflow after #353
- verified edited YAML output
- verified `git diff --check`
