### PR TITLE
feat(obsidian): add bidirectional vault sync

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -128,3 +128,7 @@ obsidian:
   export_limit: 200
   track_moc_filename: "_MOC.md"
   group_tracks_in_folders: true
+  sync_state_filename: ".paperbot-sync-state.json"
+  pending_dirname: ".paperbot-pending"
+  sync_debounce_seconds: 1.0
+  auto_watch: false

--- a/config/settings.py
+++ b/config/settings.py
@@ -144,6 +144,10 @@ class ObsidianConfig(BaseModel):
     export_limit: int = 200
     track_moc_filename: str = "_MOC.md"
     group_tracks_in_folders: bool = True
+    sync_state_filename: str = ".paperbot-sync-state.json"
+    pending_dirname: str = ".paperbot-pending"
+    sync_debounce_seconds: float = 1.0
+    auto_watch: bool = False
 
 
 class CollabHostConfig(BaseModel):
@@ -338,6 +342,10 @@ class Settings(BaseModel):
         obsidian_export_limit = os.getenv("PAPERBOT_OBSIDIAN_EXPORT_LIMIT")
         obsidian_track_moc_filename = os.getenv("PAPERBOT_OBSIDIAN_TRACK_MOC_FILENAME")
         obsidian_group_tracks = os.getenv("PAPERBOT_OBSIDIAN_GROUP_TRACKS_IN_FOLDERS")
+        obsidian_sync_state_file = os.getenv("PAPERBOT_OBSIDIAN_SYNC_STATE_FILE")
+        obsidian_pending_dirname = os.getenv("PAPERBOT_OBSIDIAN_PENDING_DIRNAME")
+        obsidian_sync_debounce = os.getenv("PAPERBOT_OBSIDIAN_SYNC_DEBOUNCE_SECONDS")
+        obsidian_auto_watch = os.getenv("PAPERBOT_OBSIDIAN_AUTO_WATCH")
         if re_enabled is not None:
             self.report_engine.enabled = re_enabled.lower() in ("1", "true", "yes", "on")
         if re_api:
@@ -401,6 +409,25 @@ class Settings(BaseModel):
             self.obsidian.track_moc_filename = obsidian_track_moc_filename
         if obsidian_group_tracks is not None:
             self.obsidian.group_tracks_in_folders = obsidian_group_tracks.lower() in (
+                "1",
+                "true",
+                "yes",
+                "on",
+            )
+        if obsidian_sync_state_file:
+            self.obsidian.sync_state_filename = obsidian_sync_state_file
+        if obsidian_pending_dirname:
+            self.obsidian.pending_dirname = obsidian_pending_dirname
+        if obsidian_sync_debounce:
+            try:
+                self.obsidian.sync_debounce_seconds = max(0.0, float(obsidian_sync_debounce))
+            except ValueError:
+                logger.warning(
+                    "Ignoring invalid PAPERBOT_OBSIDIAN_SYNC_DEBOUNCE_SECONDS=%r; expected a float",
+                    obsidian_sync_debounce,
+                )
+        if obsidian_auto_watch is not None:
+            self.obsidian.auto_watch = obsidian_auto_watch.lower() in (
                 "1",
                 "true",
                 "yes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "uvicorn[standard]>=0.32.0",
     "sse-starlette>=2.1.0",
     "python-multipart>=0.0.6",
+    "watchdog>=4.0.0",
     "SQLAlchemy>=2.0.0",
     "alembic>=1.13.0",
     "psycopg[binary]>=3.2.0",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -40,3 +40,4 @@ aiofiles>=22.1.0
 python-dotenv>=0.19.0
 json-repair>=0.22.0
 uvicorn>=0.32.0
+watchdog>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,7 @@ python-multipart>=0.0.6  # Required for file uploads
 starlette>=0.37.2,<0.39.0
 uvicorn[standard]>=0.32.0
 sse-starlette>=2.1.0
+watchdog>=4.0.0
 
 # Run/Event persistence (Phase 1A)
 SQLAlchemy>=2.0.0

--- a/src/paperbot/api/routes/obsidian.py
+++ b/src/paperbot/api/routes/obsidian.py
@@ -3,13 +3,64 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from config.settings import create_settings
+from config.settings import ObsidianConfig, create_settings
+from paperbot.application.ports.event_log_port import EventLogPort
+from paperbot.infrastructure.event_log.memory_event_log import InMemoryEventLog
 from paperbot.infrastructure.exporters import ObsidianReportExporter
+from paperbot.infrastructure.obsidian import (
+    ObsidianBidirectionalSync,
+    ObsidianVaultWatcher,
+    WATCHDOG_AVAILABLE,
+)
+from paperbot.infrastructure.stores.memory_store import SqlAlchemyMemoryStore
 
 router = APIRouter()
+
+_memory_store: Optional[SqlAlchemyMemoryStore] = None
+_vault_watcher: Optional[ObsidianVaultWatcher] = None
+
+
+def _get_memory_store() -> SqlAlchemyMemoryStore:
+    global _memory_store
+    if _memory_store is None:
+        _memory_store = SqlAlchemyMemoryStore()
+    return _memory_store
+
+
+def _get_obsidian_config() -> ObsidianConfig:
+    return create_settings().obsidian
+
+
+def _get_event_log(request: Optional[Request]) -> EventLogPort:
+    if request is None:
+        return InMemoryEventLog()
+    event_log = getattr(request.app.state, "event_log", None)
+    return event_log if isinstance(event_log, EventLogPort) else InMemoryEventLog()
+
+
+def _build_obsidian_sync_service(request: Optional[Request] = None) -> ObsidianBidirectionalSync:
+    obsidian_config = _get_obsidian_config()
+    vault_value = str(obsidian_config.vault_path or "").strip()
+    if not vault_value:
+        raise ValueError(
+            "vault_path is required. Configure obsidian.vault_path before using Obsidian sync."
+        )
+
+    return ObsidianBidirectionalSync(
+        vault_path=Path(vault_value),
+        root_dir=str(obsidian_config.root_dir or "PaperBot"),
+        memory_store=_get_memory_store(),
+        event_log=_get_event_log(request),
+        sync_state_filename=getattr(
+            obsidian_config,
+            "sync_state_filename",
+            ".paperbot-sync-state.json",
+        ),
+        pending_dirname=getattr(obsidian_config, "pending_dirname", ".paperbot-pending"),
+    )
 
 
 class ObsidianReportCitationRequest(BaseModel):
@@ -59,10 +110,40 @@ class ObsidianExportReportResponse(BaseModel):
     note_path: str
 
 
+class ObsidianSyncStatusResponse(BaseModel):
+    last_synced_at: Optional[str] = None
+    pending_count: int
+    tracked_note_count: int
+    conflict_count: int
+    state_path: str
+    pending_dir: str
+    watchdog_available: bool
+    watching: bool
+
+
+class ObsidianSyncScanResponse(BaseModel):
+    last_synced_at: str
+    scanned_notes: int
+    changed_notes: int
+    memories_created: int
+    memories_skipped: int
+    tag_updates: int
+    wikilink_updates: int
+    note_updates: int
+    conflicts_detected: int
+    pending_count: int
+
+
+class ObsidianWatchResponse(BaseModel):
+    watching: bool
+    watchdog_available: bool
+    mode: str
+    root_path: str
+
+
 @router.post("/obsidian/export-report", response_model=ObsidianExportReportResponse)
 def export_obsidian_report(req: ObsidianExportReportRequest) -> ObsidianExportReportResponse:
-    settings = create_settings()
-    obsidian_config = settings.obsidian
+    obsidian_config = _get_obsidian_config()
 
     vault_value = str(req.vault_path or obsidian_config.vault_path or "").strip()
     if not vault_value:
@@ -84,3 +165,76 @@ def export_obsidian_report(req: ObsidianExportReportRequest) -> ObsidianExportRe
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return ObsidianExportReportResponse(**result)
+
+
+@router.get("/obsidian/sync/status", response_model=ObsidianSyncStatusResponse)
+def get_obsidian_sync_status(request: Request) -> ObsidianSyncStatusResponse:
+    try:
+        status = _build_obsidian_sync_service(request).get_status().to_dict()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    status["watchdog_available"] = WATCHDOG_AVAILABLE
+    status["watching"] = _vault_watcher.is_running if _vault_watcher is not None else False
+    return ObsidianSyncStatusResponse(**status)
+
+
+@router.post("/obsidian/sync/scan", response_model=ObsidianSyncScanResponse)
+def scan_obsidian_sync(request: Request) -> ObsidianSyncScanResponse:
+    try:
+        result = _build_obsidian_sync_service(request).scan().to_dict()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return ObsidianSyncScanResponse(**result)
+
+
+@router.post("/obsidian/sync/watch/start", response_model=ObsidianWatchResponse)
+def start_obsidian_sync_watch(request: Request) -> ObsidianWatchResponse:
+    global _vault_watcher
+    obsidian_config = _get_obsidian_config()
+
+    try:
+        sync_service = _build_obsidian_sync_service(request)
+        sync_service.scan()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if _vault_watcher is not None and _vault_watcher.root_path != sync_service.root_path:
+        _vault_watcher.stop()
+        _vault_watcher = None
+
+    if _vault_watcher is None:
+        _vault_watcher = ObsidianVaultWatcher(
+            root_path=sync_service.root_path,
+            on_paths_changed=sync_service.sync_paths,
+            debounce_seconds=float(getattr(obsidian_config, "sync_debounce_seconds", 1.0)),
+        )
+
+    watching = _vault_watcher.start()
+    return ObsidianWatchResponse(
+        watching=watching,
+        watchdog_available=WATCHDOG_AVAILABLE,
+        mode="watchdog" if watching else "scan-only",
+        root_path=str(sync_service.root_path),
+    )
+
+
+@router.post("/obsidian/sync/watch/stop", response_model=ObsidianWatchResponse)
+def stop_obsidian_sync_watch(request: Request) -> ObsidianWatchResponse:
+    global _vault_watcher
+    try:
+        sync_service = _build_obsidian_sync_service(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if _vault_watcher is not None:
+        _vault_watcher.stop()
+        _vault_watcher = None
+
+    return ObsidianWatchResponse(
+        watching=False,
+        watchdog_available=WATCHDOG_AVAILABLE,
+        mode="scan-only",
+        root_path=str(sync_service.root_path),
+    )

--- a/src/paperbot/infrastructure/exporters/obsidian_exporter.py
+++ b/src/paperbot/infrastructure/exporters/obsidian_exporter.py
@@ -2,13 +2,22 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from paperbot.application.ports.vault_exporter_port import VaultExporterPort
+from paperbot.infrastructure.obsidian import (
+    PAPER_MANAGED_HEADINGS,
+    TRACK_MANAGED_HEADINGS,
+    detect_managed_conflict,
+    hash_markdown,
+    merge_user_sections,
+    parse_note_text,
+)
 
 
 DEFAULT_PAPER_TEMPLATE = """# {{ title }}
@@ -56,10 +65,13 @@ DEFAULT_PAPER_TEMPLATE = """# {{ title }}
 """
 
 _FRONTMATTER_EXPR = re.compile(r"\{\{\-?\s*frontmatter\s*\-?\}\}")
+DEFAULT_PENDING_DIRNAME = ".paperbot-pending"
 
 
 def _slugify(value: str) -> str:
-    normalized = unicodedata.normalize("NFKD", value or "").encode("ascii", "ignore").decode("ascii")
+    normalized = (
+        unicodedata.normalize("NFKD", value or "").encode("ascii", "ignore").decode("ascii")
+    )
     normalized = normalized.lower().strip()
     tokens: list[str] = []
     token: list[str] = []
@@ -210,31 +222,34 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         reference_links = self._paper_entry_links(entries=reference_entries, root_dir=root_dir)
         cited_by_links = self._paper_entry_links(entries=citation_entries, root_dir=root_dir)
 
-        frontmatter = _yaml_frontmatter(
-            {
-                "paperbot_type": "paper",
-                "paperbot_id": paper.get("id"),
-                "title": paper.get("title"),
-                "authors": list(paper.get("authors") or []),
-                "year": paper.get("year"),
-                "venue": paper.get("venue"),
-                "doi": paper.get("doi"),
-                "arxiv_id": paper.get("arxiv_id"),
-                "semantic_scholar_id": paper.get("semantic_scholar_id"),
-                "openalex_id": paper.get("openalex_id"),
-                "citation_count": paper.get("citation_count"),
-                "saved_at": saved_at,
-                "track": track.get("name") if track else None,
-                "tags": self._paper_tags(paper, track),
-                "related_papers": related_titles,
-                "cites": reference_links,
-                "cited_by": cited_by_links,
-            }
+        managed_tags = self._paper_tags(paper, track)
+        managed_links = self._dedupe_strings(
+            [track_link] + related_links + reference_links + cited_by_links
         )
+        frontmatter_payload = {
+            "paperbot_type": "paper",
+            "paperbot_id": paper.get("id"),
+            "title": paper.get("title"),
+            "authors": list(paper.get("authors") or []),
+            "year": paper.get("year"),
+            "venue": paper.get("venue"),
+            "doi": paper.get("doi"),
+            "arxiv_id": paper.get("arxiv_id"),
+            "semantic_scholar_id": paper.get("semantic_scholar_id"),
+            "openalex_id": paper.get("openalex_id"),
+            "citation_count": paper.get("citation_count"),
+            "saved_at": saved_at,
+            "track": track.get("name") if track else None,
+            "tags": managed_tags,
+            "paperbot_managed_tags": managed_tags,
+            "paperbot_managed_links": managed_links,
+            "related_papers": related_titles,
+            "cites": reference_links,
+            "cited_by": cited_by_links,
+        }
 
         body = self._render_paper_note(
             template_path=template_path,
-            frontmatter=frontmatter,
             title=note_title,
             abstract=str(paper.get("abstract") or "_No abstract available._"),
             metadata_rows=[
@@ -253,7 +268,13 @@ class ObsidianFilesystemExporter(VaultExporterPort):
             related_titles=related_titles,
         )
 
-        note_path.write_text(body.rstrip() + "\n", encoding="utf-8")
+        self._write_managed_note(
+            note_path=note_path,
+            root_path=papers_dir.parent,
+            frontmatter_payload=frontmatter_payload,
+            managed_body=body,
+            managed_headings=PAPER_MANAGED_HEADINGS,
+        )
         return {
             "title": note_title,
             "path": str(note_path),
@@ -286,23 +307,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
             group_tracks_in_folders=group_tracks_in_folders,
         )
 
-        frontmatter = _yaml_frontmatter(
-            {
-                "paperbot_type": "track",
-                "track_id": track.get("id"),
-                "user_id": track.get("user_id"),
-                "name": track.get("name"),
-                "moc_note": note_filename,
-                "paper_count": len(paper_refs),
-                "keywords": list(track.get("keywords") or []),
-                "methods": list(track.get("methods") or []),
-                "venues": list(track.get("venues") or []),
-                "is_active": track.get("is_active"),
-            }
-        )
-
         lines = [
-            frontmatter,
             f"# {track.get('name') or 'Untitled Track'}",
             "",
             str(track.get("description") or "_No description provided._"),
@@ -323,10 +328,12 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         else:
             lines.append("- _No tracked tasks._")
 
-        lines.extend([
-            "",
-            "## Milestones",
-        ])
+        lines.extend(
+            [
+                "",
+                "## Milestones",
+            ]
+        )
         milestones = list(track.get("milestones") or [])
         if milestones:
             for milestone in milestones:
@@ -336,14 +343,18 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         else:
             lines.append("- _No milestones defined._")
 
-        lines.extend([
-            "",
-            "## Tracked Scholars",
-        ])
+        lines.extend(
+            [
+                "",
+                "## Tracked Scholars",
+            ]
+        )
         scholars = list(track.get("scholars") or track.get("tracked_scholars") or [])
         if scholars:
             for scholar in scholars:
-                name = str(scholar.get("name") or scholar.get("scholar_name") or "Unknown scholar").strip()
+                name = str(
+                    scholar.get("name") or scholar.get("scholar_name") or "Unknown scholar"
+                ).strip()
                 affiliation = str(scholar.get("affiliation") or "").strip()
                 if affiliation:
                     lines.append(f"- {name} ({affiliation})")
@@ -352,16 +363,38 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         else:
             lines.append("- _No linked scholars._")
 
-        lines.extend([
-            "",
-            "## Saved Papers",
-        ])
+        lines.extend(
+            [
+                "",
+                "## Saved Papers",
+            ]
+        )
         if paper_refs:
             lines.extend([f"- {ref['link']}" for ref in paper_refs])
         else:
             lines.append("- _No saved papers exported._")
 
-        note_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+        frontmatter_payload = {
+            "paperbot_type": "track",
+            "track_id": track.get("id"),
+            "user_id": track.get("user_id"),
+            "name": track.get("name"),
+            "moc_note": note_filename,
+            "paper_count": len(paper_refs),
+            "keywords": list(track.get("keywords") or []),
+            "methods": list(track.get("methods") or []),
+            "venues": list(track.get("venues") or []),
+            "is_active": track.get("is_active"),
+            "paperbot_managed_tags": [],
+            "paperbot_managed_links": self._dedupe_strings(ref["link"] for ref in paper_refs),
+        }
+        self._write_managed_note(
+            note_path=note_path,
+            root_path=tracks_dir.parent,
+            frontmatter_payload=frontmatter_payload,
+            managed_body="\n".join(lines).rstrip() + "\n",
+            managed_headings=TRACK_MANAGED_HEADINGS,
+        )
         return {
             "title": str(track.get("name") or "Track"),
             "path": str(note_path),
@@ -487,7 +520,6 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         self,
         *,
         template_path: Optional[Path],
-        frontmatter: str,
         title: str,
         abstract: str,
         metadata_rows: List[str],
@@ -504,12 +536,12 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         environment = self._build_template_environment()
         if template_path:
             resolved = template_path.expanduser().resolve()
-            environment = self._build_template_environment(loader=FileSystemLoader(str(resolved.parent)))
+            environment = self._build_template_environment(
+                loader=FileSystemLoader(str(resolved.parent))
+            )
             template_source = resolved.read_text(encoding="utf-8")
 
-        body = environment.from_string(
-            self._strip_frontmatter_expression(template_source)
-        ).render(
+        body = environment.from_string(self._strip_frontmatter_expression(template_source)).render(
             title=title,
             abstract=abstract,
             metadata_rows=metadata_rows,
@@ -522,7 +554,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
             track=track,
             related_titles=related_titles,
         )
-        return f"{frontmatter}{body}"
+        return body.rstrip() + "\n"
 
     def _sync_paper_citation_backlinks(
         self,
@@ -571,16 +603,34 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         if not note_path.exists() or not note_path.is_file():
             return
 
-        frontmatter, body = self._read_note(note_path)
-        values = [str(item).strip() for item in list(frontmatter.get(frontmatter_key) or []) if str(item).strip()]
+        parsed = parse_note_text(
+            note_path.read_text(encoding="utf-8"),
+            managed_headings=PAPER_MANAGED_HEADINGS,
+        )
+        frontmatter = dict(parsed.frontmatter)
+        values = [
+            str(item).strip()
+            for item in list(frontmatter.get(frontmatter_key) or [])
+            if str(item).strip()
+        ]
         if link not in values:
             values.append(link)
         frontmatter[frontmatter_key] = values
+        frontmatter["paperbot_managed_links"] = self._dedupe_strings(
+            list(frontmatter.get("paperbot_managed_links") or []) + [link]
+        )
 
-        updated_body = self._upsert_markdown_section(body=body, heading=heading, links=values)
-        note_path.write_text(
-            f"{_yaml_frontmatter(frontmatter)}{updated_body.rstrip()}\n",
-            encoding="utf-8",
+        updated_body = self._upsert_markdown_section(
+            body=parsed.managed_body,
+            heading=heading,
+            links=values,
+        )
+        self._write_managed_note(
+            note_path=note_path,
+            root_path=note_path.parents[1],
+            frontmatter_payload=frontmatter,
+            managed_body=updated_body,
+            managed_headings=PAPER_MANAGED_HEADINGS,
         )
 
     @staticmethod
@@ -591,7 +641,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
             if match:
                 payload = yaml.safe_load(match.group(1)) or {}
                 if isinstance(payload, dict):
-                    return payload, text[match.end():]
+                    return payload, text[match.end() :]
         return {}, text
 
     @staticmethod
@@ -606,9 +656,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         section_text = "\n".join(section_lines).rstrip()
 
         trimmed = body.rstrip()
-        pattern = re.compile(
-            rf"(?ms)^## {re.escape(heading)}\n.*?(?=^## |\Z)"
-        )
+        pattern = re.compile(rf"(?ms)^## {re.escape(heading)}\n.*?(?=^## |\Z)")
         if pattern.search(trimmed):
             updated = pattern.sub(section_text + "\n", trimmed)
         else:
@@ -775,3 +823,100 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         if label:
             return f"[[{target}|{label}]]"
         return f"[[{target}]]"
+
+    def _write_managed_note(
+        self,
+        *,
+        note_path: Path,
+        root_path: Path,
+        frontmatter_payload: Dict[str, Any],
+        managed_body: str,
+        managed_headings: Sequence[str],
+        pending_dirname: str = DEFAULT_PENDING_DIRNAME,
+    ) -> None:
+        note_path.parent.mkdir(parents=True, exist_ok=True)
+        existing_note = (
+            parse_note_text(
+                note_path.read_text(encoding="utf-8"),
+                managed_headings=managed_headings,
+            )
+            if note_path.exists()
+            else None
+        )
+        conflict = (
+            detect_managed_conflict(
+                note_path=note_path,
+                frontmatter=existing_note.frontmatter,
+                managed_body=existing_note.managed_body,
+            )
+            if existing_note is not None
+            else None
+        )
+
+        merged_body = merge_user_sections(
+            managed_body,
+            existing_note.user_sections if existing_note is not None else [],
+        )
+        payload = dict(frontmatter_payload)
+        payload["paperbot_exported_at"] = datetime.now(timezone.utc).isoformat()
+        payload["paperbot_managed_hash"] = hash_markdown(managed_body)
+
+        if conflict is not None:
+            pending_path = self._pending_note_path(
+                note_path=note_path,
+                root_path=root_path,
+                pending_dirname=pending_dirname,
+            )
+            pending_path.parent.mkdir(parents=True, exist_ok=True)
+            pending_payload = dict(payload)
+            pending_payload.update(
+                {
+                    "paperbot_status": "pending",
+                    "paperbot_pending_for": str(note_path),
+                    "paperbot_conflict_reason": conflict.reason,
+                    "paperbot_expected_managed_hash": conflict.expected_hash,
+                    "paperbot_actual_managed_hash": conflict.actual_hash,
+                    "paperbot_conflict_detected_at": conflict.detected_at,
+                }
+            )
+            pending_path.write_text(
+                f"{_yaml_frontmatter(pending_payload)}{merged_body.rstrip()}\n",
+                encoding="utf-8",
+            )
+            return
+
+        note_path.write_text(
+            f"{_yaml_frontmatter(payload)}{merged_body.rstrip()}\n",
+            encoding="utf-8",
+        )
+        pending_path = self._pending_note_path(
+            note_path=note_path,
+            root_path=root_path,
+            pending_dirname=pending_dirname,
+        )
+        if pending_path.exists():
+            pending_path.unlink()
+
+    @staticmethod
+    def _pending_note_path(
+        *,
+        note_path: Path,
+        root_path: Path,
+        pending_dirname: str,
+    ) -> Path:
+        return root_path / pending_dirname / note_path.relative_to(root_path)
+
+    @staticmethod
+    def _dedupe_strings(values: Iterable[Optional[str]]) -> List[str]:
+        items: List[str] = []
+        seen: set[str] = set()
+        for raw_value in values:
+            value = str(raw_value or "").strip()
+            if not value:
+                continue
+            key = value.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            items.append(value)
+        return items

--- a/src/paperbot/infrastructure/obsidian/__init__.py
+++ b/src/paperbot/infrastructure/obsidian/__init__.py
@@ -1,0 +1,34 @@
+from .conflict import ObsidianManagedConflict, detect_managed_conflict
+from .parser import (
+    MarkdownSection,
+    ParsedObsidianNote,
+    hash_markdown,
+    merge_user_sections,
+    parse_note_text,
+)
+from .sync import (
+    ObsidianBidirectionalSync,
+    ObsidianSyncScanResult,
+    ObsidianSyncStatus,
+    PAPER_MANAGED_HEADINGS,
+    TRACK_MANAGED_HEADINGS,
+)
+from .watcher import DebouncedPathQueue, ObsidianVaultWatcher, WATCHDOG_AVAILABLE
+
+__all__ = [
+    "DebouncedPathQueue",
+    "MarkdownSection",
+    "ObsidianBidirectionalSync",
+    "ObsidianManagedConflict",
+    "ObsidianSyncScanResult",
+    "ObsidianSyncStatus",
+    "ObsidianVaultWatcher",
+    "PAPER_MANAGED_HEADINGS",
+    "ParsedObsidianNote",
+    "TRACK_MANAGED_HEADINGS",
+    "WATCHDOG_AVAILABLE",
+    "detect_managed_conflict",
+    "hash_markdown",
+    "merge_user_sections",
+    "parse_note_text",
+]

--- a/src/paperbot/infrastructure/obsidian/conflict.py
+++ b/src/paperbot/infrastructure/obsidian/conflict.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from .parser import hash_markdown
+
+
+@dataclass(frozen=True)
+class ObsidianManagedConflict:
+    note_path: str
+    reason: str
+    expected_hash: str
+    actual_hash: str
+    detected_at: str
+    exported_at: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def detect_managed_conflict(
+    *,
+    note_path: Path,
+    frontmatter: Mapping[str, Any],
+    managed_body: str,
+) -> Optional[ObsidianManagedConflict]:
+    expected_hash = str(frontmatter.get("paperbot_managed_hash") or "").strip()
+    if not expected_hash:
+        return None
+
+    actual_hash = hash_markdown(managed_body)
+    if actual_hash == expected_hash:
+        return None
+
+    return ObsidianManagedConflict(
+        note_path=str(note_path),
+        reason="paperbot_managed_hash_mismatch",
+        expected_hash=expected_hash,
+        actual_hash=actual_hash,
+        detected_at=datetime.now(timezone.utc).isoformat(),
+        exported_at=_coerce_optional_string(frontmatter.get("paperbot_exported_at")),
+    )
+
+
+def _coerce_optional_string(value: Any) -> Optional[str]:
+    normalized = str(value or "").strip()
+    return normalized or None

--- a/src/paperbot/infrastructure/obsidian/parser.py
+++ b/src/paperbot/infrastructure/obsidian/parser.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Sequence
+
+import yaml
+
+_FRONTMATTER_PATTERN = re.compile(r"^---\n(.*?)\n---\n?", flags=re.DOTALL)
+_SECTION_PATTERN = re.compile(r"(?m)^##\s+(.+?)\s*$")
+_TITLE_PATTERN = re.compile(r"(?m)^#\s+(.+?)\s*$")
+_INLINE_TAG_PATTERN = re.compile(r"(?<![\w/])#([A-Za-z][\w/-]*)")
+_WIKILINK_PATTERN = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
+
+
+@dataclass(frozen=True)
+class MarkdownSection:
+    heading: str
+    markdown: str
+    is_managed: bool
+
+
+@dataclass(frozen=True)
+class ParsedObsidianNote:
+    frontmatter: Dict[str, Any]
+    body: str
+    title: str
+    managed_body: str
+    user_sections: List[MarkdownSection]
+    all_tags: List[str]
+    user_tags: List[str]
+    all_wikilinks: List[str]
+    user_wikilinks: List[str]
+
+
+def hash_markdown(text: str) -> str:
+    normalized_lines = [line.rstrip() for line in text.replace("\r\n", "\n").split("\n")]
+    normalized = "\n".join(normalized_lines).strip()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def parse_note_text(
+    text: str,
+    *,
+    managed_headings: Iterable[str] | None = None,
+) -> ParsedObsidianNote:
+    frontmatter, body = split_frontmatter(text)
+    managed_heading_set = {
+        value.strip().casefold() for value in (managed_headings or ()) if value.strip()
+    }
+    prefix, sections = split_sections(body, managed_headings=managed_heading_set)
+    managed_chunks: List[str] = []
+    if prefix.strip():
+        managed_chunks.append(prefix.strip())
+
+    user_sections: List[MarkdownSection] = []
+    for section in sections:
+        if section.is_managed:
+            managed_chunks.append(section.markdown.strip())
+        else:
+            user_sections.append(section)
+
+    managed_body = _join_markdown_chunks(managed_chunks)
+    title = extract_title(body)
+    all_tags = extract_tags(body=body, frontmatter=frontmatter)
+    managed_tags = {
+        normalize_tag(tag)
+        for tag in _coerce_string_list(frontmatter.get("paperbot_managed_tags"))
+        if normalize_tag(tag)
+    }
+    user_tags = [tag for tag in all_tags if tag not in managed_tags]
+
+    all_wikilinks = extract_wikilinks(body)
+    managed_wikilinks = {
+        normalize_wikilink_target(target)
+        for target in _coerce_string_list(frontmatter.get("paperbot_managed_links"))
+        if normalize_wikilink_target(target)
+    }
+    user_wikilinks = [target for target in all_wikilinks if target not in managed_wikilinks]
+
+    return ParsedObsidianNote(
+        frontmatter=frontmatter,
+        body=body,
+        title=title,
+        managed_body=managed_body,
+        user_sections=user_sections,
+        all_tags=all_tags,
+        user_tags=user_tags,
+        all_wikilinks=all_wikilinks,
+        user_wikilinks=user_wikilinks,
+    )
+
+
+def split_frontmatter(text: str) -> tuple[Dict[str, Any], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+
+    match = _FRONTMATTER_PATTERN.match(text)
+    if match is None:
+        return {}, text
+
+    payload = yaml.safe_load(match.group(1)) or {}
+    if not isinstance(payload, dict):
+        raise ValueError("Obsidian frontmatter must be a mapping")
+    return dict(payload), text[match.end() :]
+
+
+def split_sections(
+    body: str,
+    *,
+    managed_headings: Iterable[str] | None = None,
+) -> tuple[str, List[MarkdownSection]]:
+    managed_heading_set = {
+        value.strip().casefold() for value in (managed_headings or ()) if value.strip()
+    }
+    matches = list(_SECTION_PATTERN.finditer(body))
+    if not matches:
+        return body, []
+
+    prefix = body[: matches[0].start()]
+    sections: List[MarkdownSection] = []
+    for index, match in enumerate(matches):
+        start = match.start()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        heading = match.group(1).strip()
+        markdown = body[start:end].strip()
+        sections.append(
+            MarkdownSection(
+                heading=heading,
+                markdown=markdown,
+                is_managed=heading.casefold() in managed_heading_set,
+            )
+        )
+    return prefix, sections
+
+
+def extract_title(body: str) -> str:
+    match = _TITLE_PATTERN.search(body)
+    if match is None:
+        return ""
+    return match.group(1).strip()
+
+
+def extract_tags(*, body: str, frontmatter: Dict[str, Any]) -> List[str]:
+    values: List[str] = []
+    for raw_tag in _coerce_string_list(frontmatter.get("tags")):
+        normalized = normalize_tag(raw_tag)
+        if normalized:
+            values.append(normalized)
+    for match in _INLINE_TAG_PATTERN.finditer(body):
+        normalized = normalize_tag(match.group(1))
+        if normalized:
+            values.append(normalized)
+    return _dedupe(values)
+
+
+def extract_wikilinks(body: str) -> List[str]:
+    return _dedupe(
+        normalize_wikilink_target(match.group(1))
+        for match in _WIKILINK_PATTERN.finditer(body)
+        if normalize_wikilink_target(match.group(1))
+    )
+
+
+def merge_user_sections(managed_body: str, user_sections: Sequence[MarkdownSection]) -> str:
+    chunks: List[str] = []
+    if managed_body.strip():
+        chunks.append(managed_body.strip())
+    chunks.extend(section.markdown.strip() for section in user_sections if section.markdown.strip())
+    return _join_markdown_chunks(chunks)
+
+
+def user_sections_hash(user_sections: Sequence[MarkdownSection]) -> str:
+    return hash_markdown(_join_markdown_chunks(section.markdown for section in user_sections))
+
+
+def normalize_tag(value: str) -> str:
+    normalized = str(value or "").strip()
+    while normalized.startswith("#"):
+        normalized = normalized[1:]
+    return normalized.strip().lower()
+
+
+def normalize_wikilink_target(value: str) -> str:
+    return str(value or "").strip()
+
+
+def _coerce_string_list(value: Any) -> List[str]:
+    if isinstance(value, str):
+        return [value]
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    items: List[str] = []
+    seen: set[str] = set()
+    for raw_value in values:
+        value = str(raw_value or "").strip()
+        if not value:
+            continue
+        key = value.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append(value)
+    return items
+
+
+def _join_markdown_chunks(chunks: Iterable[str]) -> str:
+    values = [str(chunk).strip() for chunk in chunks if str(chunk).strip()]
+    if not values:
+        return ""
+    return "\n\n".join(values).rstrip() + "\n"

--- a/src/paperbot/infrastructure/obsidian/sync.py
+++ b/src/paperbot/infrastructure/obsidian/sync.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Protocol, Sequence, Tuple
+from uuid import uuid4
+
+from paperbot.application.ports.event_log_port import EventLogPort
+from paperbot.application.ports.memory_port import MemoryPort
+from paperbot.memory.schema import MemoryCandidate
+
+from .conflict import ObsidianManagedConflict, detect_managed_conflict
+from .parser import ParsedObsidianNote, parse_note_text, user_sections_hash
+
+PAPER_MANAGED_HEADINGS: tuple[str, ...] = (
+    "Summary",
+    "Metadata",
+    "Tracks",
+    "Related Papers",
+    "References",
+    "Cited By",
+    "Links",
+)
+TRACK_MANAGED_HEADINGS: tuple[str, ...] = (
+    "Focus",
+    "Research Tasks",
+    "Milestones",
+    "Tracked Scholars",
+    "Saved Papers",
+)
+
+
+@dataclass(frozen=True)
+class ObsidianSyncStatus:
+    last_synced_at: Optional[str]
+    pending_count: int
+    tracked_note_count: int
+    conflict_count: int
+    state_path: str
+    pending_dir: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ObsidianSyncScanResult:
+    last_synced_at: str
+    scanned_notes: int
+    changed_notes: int
+    memories_created: int
+    memories_skipped: int
+    tag_updates: int
+    wikilink_updates: int
+    note_updates: int
+    conflicts_detected: int
+    pending_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class ObsidianBidirectionalSync:
+    def __init__(
+        self,
+        *,
+        vault_path: Path,
+        root_dir: str,
+        memory_store: MemoryPort,
+        event_log: EventLogPort,
+        sync_state_filename: str = ".paperbot-sync-state.json",
+        pending_dirname: str = ".paperbot-pending",
+    ) -> None:
+        self._vault_path = Path(vault_path).expanduser()
+        self._root_dir = str(root_dir or "PaperBot").strip() or "PaperBot"
+        self._memory_store = memory_store
+        self._event_log = event_log
+        self._sync_state_filename = str(sync_state_filename or ".paperbot-sync-state.json")
+        self._pending_dirname = str(pending_dirname or ".paperbot-pending")
+
+    @property
+    def root_path(self) -> Path:
+        return self._vault_path / self._root_dir
+
+    @property
+    def state_path(self) -> Path:
+        return self.root_path / self._sync_state_filename
+
+    @property
+    def pending_dir(self) -> Path:
+        return self.root_path / self._pending_dirname
+
+    def get_status(self) -> ObsidianSyncStatus:
+        self._ensure_root_path()
+        state = self._load_state()
+        return ObsidianSyncStatus(
+            last_synced_at=_coerce_optional_string(state.get("last_synced_at")),
+            pending_count=self._pending_count(),
+            tracked_note_count=len(self._notes_state(state)),
+            conflict_count=len(self._conflicts_state(state)),
+            state_path=str(self.state_path),
+            pending_dir=str(self.pending_dir),
+        )
+
+    def scan(self) -> ObsidianSyncScanResult:
+        return self._scan(paths=None)
+
+    def sync_paths(self, paths: Sequence[Path]) -> ObsidianSyncScanResult:
+        return self._scan(paths=paths)
+
+    def _scan(self, paths: Optional[Sequence[Path]]) -> ObsidianSyncScanResult:
+        self._ensure_root_path()
+        state = self._load_state()
+        notes_state = self._notes_state(state)
+        conflicts_state = self._conflicts_state(state)
+        run_id = f"obsidian-sync-{uuid4().hex[:12]}"
+        last_synced_at = datetime.now(timezone.utc).isoformat()
+
+        scanned_notes = 0
+        changed_notes = 0
+        memories_created = 0
+        memories_skipped = 0
+        tag_updates = 0
+        wikilink_updates = 0
+        note_updates = 0
+        conflicts_detected = 0
+
+        candidate_paths = self._resolve_candidate_paths(paths)
+        seen_rel_paths: set[str] = set()
+        for note_path in candidate_paths:
+            relative_path = self._relative_note_path(note_path)
+            seen_rel_paths.add(relative_path)
+            previous = notes_state.get(relative_path)
+
+            if not note_path.exists():
+                if previous is not None:
+                    changed_notes += 1
+                    notes_state.pop(relative_path, None)
+                    conflicts_state.pop(relative_path, None)
+                    self._append_event(
+                        run_id=run_id,
+                        event_type="obsidian.note.deleted",
+                        payload={"path": relative_path},
+                    )
+                continue
+
+            if not note_path.is_file() or note_path.suffix.lower() != ".md":
+                continue
+
+            parsed_note = self._parse_note(note_path=note_path, run_id=run_id)
+            if parsed_note is None:
+                continue
+
+            paperbot_type = str(parsed_note.frontmatter.get("paperbot_type") or "").strip().lower()
+            if paperbot_type not in {"paper", "track"}:
+                continue
+
+            scanned_notes += 1
+            current_snapshot = self._snapshot_for_note(note_path=note_path, note=parsed_note)
+            if previous == current_snapshot:
+                continue
+
+            changed_notes += 1
+            notes_state[relative_path] = current_snapshot
+
+            conflict = detect_managed_conflict(
+                note_path=note_path,
+                frontmatter=parsed_note.frontmatter,
+                managed_body=parsed_note.managed_body,
+            )
+            if conflict is not None:
+                conflicts_state[relative_path] = conflict.to_dict()
+                conflicts_detected += 1
+                self._append_conflict_event(run_id=run_id, conflict=conflict, path=relative_path)
+            else:
+                conflicts_state.pop(relative_path, None)
+
+            if previous is None:
+                self._append_event(
+                    run_id=run_id,
+                    event_type="obsidian.note.baseline_recorded",
+                    payload={
+                        "path": relative_path,
+                        "paperbot_type": paperbot_type,
+                    },
+                )
+                if parsed_note.user_sections:
+                    created_count, skipped_count = self._sync_user_notes(
+                        note=parsed_note,
+                        path=relative_path,
+                    )
+                    memories_created += created_count
+                    memories_skipped += skipped_count
+                    if created_count or skipped_count:
+                        note_updates += 1
+                continue
+
+            added_tags = _difference(parsed_note.user_tags, previous.get("tags"))
+            added_wikilinks = _difference(parsed_note.user_wikilinks, previous.get("wikilinks"))
+            notes_changed = (
+                previous.get("user_sections_hash") != current_snapshot["user_sections_hash"]
+            )
+
+            created_count, skipped_count = self._sync_note_delta(
+                note=parsed_note,
+                path=relative_path,
+                added_tags=added_tags,
+                added_wikilinks=added_wikilinks,
+                user_notes_changed=notes_changed,
+            )
+            memories_created += created_count
+            memories_skipped += skipped_count
+            tag_updates += len(added_tags)
+            wikilink_updates += len(added_wikilinks)
+            note_updates += 1 if notes_changed else 0
+
+        if paths is None:
+            missing_paths = [path for path in list(notes_state) if path not in seen_rel_paths]
+            for missing_path in missing_paths:
+                notes_state.pop(missing_path, None)
+                conflicts_state.pop(missing_path, None)
+
+        state["last_synced_at"] = last_synced_at
+        self._save_state(state)
+        return ObsidianSyncScanResult(
+            last_synced_at=last_synced_at,
+            scanned_notes=scanned_notes,
+            changed_notes=changed_notes,
+            memories_created=memories_created,
+            memories_skipped=memories_skipped,
+            tag_updates=tag_updates,
+            wikilink_updates=wikilink_updates,
+            note_updates=note_updates,
+            conflicts_detected=conflicts_detected,
+            pending_count=self._pending_count(),
+        )
+
+    def _sync_note_delta(
+        self,
+        *,
+        note: ParsedObsidianNote,
+        path: str,
+        added_tags: Sequence[str],
+        added_wikilinks: Sequence[str],
+        user_notes_changed: bool,
+    ) -> Tuple[int, int]:
+        created_total = 0
+        skipped_total = 0
+        user_id, scope_type, scope_id = self._scope_for_note(note)
+        title = note.title or Path(path).stem
+
+        if added_tags:
+            memories = [
+                MemoryCandidate(
+                    kind="keyword_set",
+                    content=f'Obsidian tag for "{title}": {tag}',
+                    confidence=0.85,
+                    tags=["obsidian", "tag", tag],
+                    evidence={"path": path, "tag": tag},
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                    status="approved",
+                )
+                for tag in added_tags
+            ]
+            created, skipped = self._write_memories(user_id=user_id, memories=memories)
+            created_total += created
+            skipped_total += skipped
+            for tag in added_tags:
+                self._append_event(
+                    run_id=f"obsidian-sync-tags-{uuid4().hex[:10]}",
+                    event_type="obsidian.note.tag_added",
+                    payload={"path": path, "tag": tag, "title": title},
+                )
+
+        if added_wikilinks:
+            memories = [
+                MemoryCandidate(
+                    kind="fact",
+                    content=f'Obsidian wiki-link from "{title}" to "{target}"',
+                    confidence=0.8,
+                    tags=["obsidian", "wikilink"],
+                    evidence={"path": path, "target": target},
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                    status="approved",
+                )
+                for target in added_wikilinks
+            ]
+            created, skipped = self._write_memories(user_id=user_id, memories=memories)
+            created_total += created
+            skipped_total += skipped
+            for target in added_wikilinks:
+                self._append_event(
+                    run_id=f"obsidian-sync-links-{uuid4().hex[:10]}",
+                    event_type="obsidian.note.wikilink_added",
+                    payload={"path": path, "target": target, "title": title},
+                )
+
+        if user_notes_changed:
+            created, skipped = self._sync_user_notes(note=note, path=path)
+            created_total += created
+            skipped_total += skipped
+
+        return created_total, skipped_total
+
+    def _sync_user_notes(self, *, note: ParsedObsidianNote, path: str) -> Tuple[int, int]:
+        if not note.user_sections:
+            return 0, 0
+
+        user_id, scope_type, scope_id = self._scope_for_note(note)
+        title = note.title or Path(path).stem
+        memories: List[MemoryCandidate] = []
+        for section in note.user_sections:
+            content = _section_content(section.markdown)
+            if not content:
+                continue
+            memories.append(
+                MemoryCandidate(
+                    kind="note",
+                    content=f'Obsidian personal note for "{title}" ({section.heading}): {content}',
+                    confidence=0.7,
+                    tags=["obsidian", "personal-note"],
+                    evidence={"path": path, "heading": section.heading},
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                    status="approved",
+                )
+            )
+
+        if not memories:
+            return 0, 0
+
+        created, skipped = self._write_memories(user_id=user_id, memories=memories)
+        self._append_event(
+            run_id=f"obsidian-sync-notes-{uuid4().hex[:10]}",
+            event_type="obsidian.note.user_sections_synced",
+            payload={"path": path, "sections": [section.heading for section in note.user_sections]},
+        )
+        return created, skipped
+
+    def _write_memories(self, *, user_id: str, memories: List[MemoryCandidate]) -> Tuple[int, int]:
+        created, skipped, _ = self._memory_store.add_memories(
+            user_id=user_id,
+            memories=memories,
+            actor_id="obsidian-sync",
+        )
+        return created, skipped
+
+    def _scope_for_note(self, note: ParsedObsidianNote) -> tuple[str, str, Optional[str]]:
+        frontmatter = note.frontmatter
+        user_id = _coerce_optional_string(frontmatter.get("user_id")) or "default"
+        paperbot_type = str(frontmatter.get("paperbot_type") or "").strip().lower()
+        if paperbot_type == "track":
+            scope_id = _coerce_optional_string(frontmatter.get("track_id")) or (
+                _coerce_optional_string(frontmatter.get("name")) or note.title or "track"
+            )
+            return user_id, "track", scope_id
+
+        if paperbot_type == "paper":
+            scope_id = (
+                _coerce_optional_string(frontmatter.get("paperbot_id"))
+                or _coerce_optional_string(frontmatter.get("semantic_scholar_id"))
+                or _coerce_optional_string(frontmatter.get("doi"))
+                or _coerce_optional_string(frontmatter.get("arxiv_id"))
+                or _coerce_optional_string(frontmatter.get("openalex_id"))
+                or note.title
+                or "paper"
+            )
+            return user_id, "paper", scope_id
+
+        return user_id, "global", None
+
+    def _parse_note(self, *, note_path: Path, run_id: str) -> Optional[ParsedObsidianNote]:
+        try:
+            text = note_path.read_text(encoding="utf-8")
+            managed_headings = self._managed_headings_for_type(note_path=note_path, text=text)
+            return parse_note_text(text, managed_headings=managed_headings)
+        except Exception as exc:
+            self._append_event(
+                run_id=run_id,
+                event_type="obsidian.note.parse_failed",
+                payload={"path": self._relative_note_path(note_path), "error": str(exc)},
+            )
+            return None
+
+    def _managed_headings_for_type(self, *, note_path: Path, text: str) -> Sequence[str]:
+        try:
+            note = parse_note_text(text)
+        except Exception:
+            return ()
+        paperbot_type = str(note.frontmatter.get("paperbot_type") or "").strip().lower()
+        if paperbot_type == "paper":
+            return PAPER_MANAGED_HEADINGS
+        if paperbot_type == "track":
+            return TRACK_MANAGED_HEADINGS
+        if note_path.name == "MOC.md":
+            return ("Tracks", "Papers")
+        return ()
+
+    def _resolve_candidate_paths(self, paths: Optional[Sequence[Path]]) -> List[Path]:
+        if paths is None:
+            return sorted(self._iter_note_paths())
+
+        resolved: List[Path] = []
+        for raw_path in paths:
+            candidate = Path(raw_path).expanduser()
+            if not candidate.is_absolute():
+                candidate = (self.root_path / candidate).resolve()
+            resolved.append(candidate)
+        return sorted({path for path in resolved})
+
+    def _iter_note_paths(self) -> Iterable[Path]:
+        pending_prefix = self.pending_dir.resolve()
+        for note_path in self.root_path.rglob("*.md"):
+            resolved = note_path.resolve()
+            if resolved == self.state_path.resolve():
+                continue
+            if pending_prefix in resolved.parents:
+                continue
+            yield resolved
+
+    def _snapshot_for_note(self, *, note_path: Path, note: ParsedObsidianNote) -> Dict[str, Any]:
+        return {
+            "mtime_ns": note_path.stat().st_mtime_ns,
+            "paperbot_type": str(note.frontmatter.get("paperbot_type") or "").strip().lower(),
+            "managed_hash": _coerce_optional_string(note.frontmatter.get("paperbot_managed_hash")),
+            "tags": list(note.user_tags),
+            "wikilinks": list(note.user_wikilinks),
+            "user_sections_hash": user_sections_hash(note.user_sections),
+        }
+
+    def _append_conflict_event(
+        self,
+        *,
+        run_id: str,
+        conflict: ObsidianManagedConflict,
+        path: str,
+    ) -> None:
+        self._append_event(
+            run_id=run_id,
+            event_type="obsidian.note.conflict_detected",
+            payload={
+                "path": path,
+                "reason": conflict.reason,
+                "expected_hash": conflict.expected_hash,
+                "actual_hash": conflict.actual_hash,
+                "detected_at": conflict.detected_at,
+            },
+        )
+
+    def _append_event(self, *, run_id: str, event_type: str, payload: Mapping[str, Any]) -> None:
+        self._event_log.append(
+            {
+                "run_id": run_id,
+                "trace_id": run_id,
+                "workflow": "obsidian_sync",
+                "stage": "scan",
+                "agent_name": "obsidian-sync",
+                "role": "system",
+                "type": event_type,
+                "payload": dict(payload),
+                "ts": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+
+    def _ensure_root_path(self) -> None:
+        if not self._vault_path.exists() or not self._vault_path.is_dir():
+            raise ValueError("vault_path must be an existing directory")
+        if not self.root_path.exists() or not self.root_path.is_dir():
+            raise ValueError("obsidian root_dir must already exist inside the vault")
+
+    def _pending_count(self) -> int:
+        if not self.pending_dir.exists():
+            return 0
+        return sum(1 for _ in self.pending_dir.rglob("*.md"))
+
+    def _load_state(self) -> Dict[str, Any]:
+        if not self.state_path.exists():
+            return {"last_synced_at": None, "notes": {}, "conflicts": {}}
+        payload = json.loads(self.state_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("Obsidian sync state file must contain a JSON object")
+        payload.setdefault("last_synced_at", None)
+        payload.setdefault("notes", {})
+        payload.setdefault("conflicts", {})
+        return payload
+
+    def _save_state(self, state: Dict[str, Any]) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self.state_path.write_text(
+            json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def _notes_state(self, state: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+        notes = state.setdefault("notes", {})
+        if not isinstance(notes, dict):
+            raise ValueError("Obsidian sync notes state must be a JSON object")
+        return notes
+
+    def _conflicts_state(self, state: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+        conflicts = state.setdefault("conflicts", {})
+        if not isinstance(conflicts, dict):
+            raise ValueError("Obsidian sync conflicts state must be a JSON object")
+        return conflicts
+
+    def _relative_note_path(self, note_path: Path) -> str:
+        return str(note_path.resolve().relative_to(self.root_path.resolve()))
+
+
+def _coerce_optional_string(value: Any) -> Optional[str]:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _difference(current: Sequence[str], previous: Any) -> List[str]:
+    previous_set = {
+        str(item).strip().casefold() for item in list(previous or []) if str(item).strip()
+    }
+    return [item for item in current if item.casefold() not in previous_set]
+
+
+def _section_content(markdown: str) -> str:
+    lines = str(markdown or "").splitlines()
+    if lines and lines[0].startswith("## "):
+        lines = lines[1:]
+    content = "\n".join(lines).strip()
+    return content[:1000]

--- a/src/paperbot/infrastructure/obsidian/watcher.py
+++ b/src/paperbot/infrastructure/obsidian/watcher.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional
+
+try:
+    from watchdog.events import FileSystemEvent, FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    WATCHDOG_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised in environments without watchdog installed
+    FileSystemEvent = object  # type: ignore[assignment]
+    FileSystemEventHandler = object  # type: ignore[assignment]
+    Observer = None  # type: ignore[assignment]
+    WATCHDOG_AVAILABLE = False
+
+
+class DebouncedPathQueue:
+    def __init__(
+        self,
+        *,
+        debounce_seconds: float,
+        time_fn: Callable[[], float] | None = None,
+    ) -> None:
+        self._debounce_seconds = max(0.0, float(debounce_seconds))
+        self._time_fn = time_fn or time.monotonic
+        self._pending: Dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def push(self, path: Path) -> None:
+        normalized = str(Path(path).expanduser())
+        if not normalized:
+            return
+        with self._lock:
+            self._pending[normalized] = self._time_fn() + self._debounce_seconds
+
+    def flush_ready(self) -> List[Path]:
+        now = self._time_fn()
+        ready: List[Path] = []
+        with self._lock:
+            for raw_path, ready_at in list(self._pending.items()):
+                if ready_at > now:
+                    continue
+                ready.append(Path(raw_path))
+                self._pending.pop(raw_path, None)
+        return sorted(ready)
+
+    def flush_all(self) -> List[Path]:
+        with self._lock:
+            ready = [Path(raw_path) for raw_path in self._pending]
+            self._pending.clear()
+        return sorted(ready)
+
+
+class ObsidianVaultWatcher:
+    def __init__(
+        self,
+        *,
+        root_path: Path,
+        on_paths_changed: Callable[[List[Path]], object],
+        debounce_seconds: float = 1.0,
+        poll_interval_seconds: float = 0.25,
+    ) -> None:
+        self._root_path = Path(root_path).expanduser().resolve()
+        self._on_paths_changed = on_paths_changed
+        self._debounce_queue = DebouncedPathQueue(debounce_seconds=debounce_seconds)
+        self._poll_interval_seconds = max(0.05, float(poll_interval_seconds))
+        self._observer: Optional[Observer] = None
+        self._stop_event = threading.Event()
+        self._flush_thread: Optional[threading.Thread] = None
+        self._is_running = False
+
+    @property
+    def is_available(self) -> bool:
+        return WATCHDOG_AVAILABLE
+
+    @property
+    def is_running(self) -> bool:
+        return self._is_running
+
+    @property
+    def root_path(self) -> Path:
+        return self._root_path
+
+    def start(self) -> bool:
+        if self._is_running:
+            return True
+        if not WATCHDOG_AVAILABLE or Observer is None:
+            return False
+        if not self._root_path.exists() or not self._root_path.is_dir():
+            raise ValueError("Obsidian watcher root_path must be an existing directory")
+
+        self._stop_event.clear()
+        self._observer = Observer()
+        self._observer.schedule(_WatchdogEventHandler(self), str(self._root_path), recursive=True)
+        self._observer.start()
+
+        self._flush_thread = threading.Thread(target=self._flush_loop, daemon=True)
+        self._flush_thread.start()
+        self._is_running = True
+        return True
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._observer is not None:
+            self._observer.stop()
+            self._observer.join(timeout=2.0)
+            self._observer = None
+        if self._flush_thread is not None:
+            self._flush_thread.join(timeout=2.0)
+            self._flush_thread = None
+        self._is_running = False
+
+    def record_event(self, path: Path) -> None:
+        candidate = Path(path).expanduser()
+        if candidate.suffix.lower() != ".md":
+            return
+        self._debounce_queue.push(
+            candidate.resolve()
+            if candidate.is_absolute()
+            else (self._root_path / candidate).resolve()
+        )
+
+    def flush_pending(self) -> List[Path]:
+        ready_paths = self._debounce_queue.flush_all()
+        if ready_paths:
+            self._on_paths_changed(ready_paths)
+        return ready_paths
+
+    def _flush_loop(self) -> None:
+        while not self._stop_event.is_set():
+            ready_paths = self._debounce_queue.flush_ready()
+            if ready_paths:
+                self._on_paths_changed(ready_paths)
+            self._stop_event.wait(self._poll_interval_seconds)
+
+
+class _WatchdogEventHandler(FileSystemEventHandler):
+    def __init__(self, watcher: ObsidianVaultWatcher) -> None:
+        super().__init__()
+        self._watcher = watcher
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        self._record_event(event)
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        self._record_event(event)
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        self._record_event(event)
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        src_path = getattr(event, "src_path", None)
+        dest_path = getattr(event, "dest_path", None)
+        if src_path:
+            self._watcher.record_event(Path(str(src_path)))
+        if dest_path:
+            self._watcher.record_event(Path(str(dest_path)))
+
+    def _record_event(self, event: FileSystemEvent) -> None:
+        if getattr(event, "is_directory", False):
+            return
+        src_path = getattr(event, "src_path", None)
+        if src_path:
+            self._watcher.record_event(Path(str(src_path)))

--- a/tests/unit/test_obsidian_exporter.py
+++ b/tests/unit/test_obsidian_exporter.py
@@ -79,9 +79,14 @@ def test_export_library_snapshot_writes_paper_track_and_moc_notes(tmp_path: Path
     assert "cites:" in paper_body
     assert "cited_by:" in paper_body
     assert "## References" in paper_body
-    assert "[[PaperBot/Papers/2025-prior-compression-work-prior|Prior Compression Work]]" in paper_body
+    assert (
+        "[[PaperBot/Papers/2025-prior-compression-work-prior|Prior Compression Work]]" in paper_body
+    )
     assert "## Cited By" in paper_body
-    assert "[[PaperBot/Papers/2027-future-compression-follow-up-future|Future Compression Follow-up]]" in paper_body
+    assert (
+        "[[PaperBot/Papers/2027-future-compression-follow-up-future|Future Compression Follow-up]]"
+        in paper_body
+    )
 
     track_body = track_note.read_text(encoding="utf-8")
     assert "paperbot_type: track" in track_body
@@ -154,8 +159,13 @@ def test_export_library_snapshot_supports_custom_template_and_related_links(tmp_
     assert "related_papers:" in paper_note
     assert "Prompt Compression Survey" in paper_note
     assert "Contains &lt;script&gt;alert(1)&lt;/script&gt; &amp; evidence." in paper_note
-    assert "[[PaperBot/Papers/2025-prompt-compression-survey|Prompt Compression Survey]]" in paper_note
-    assert "[[PaperBot/Papers/context-distillation-for-llms|Context Distillation for LLMs]]" in paper_note
+    assert (
+        "[[PaperBot/Papers/2025-prompt-compression-survey|Prompt Compression Survey]]" in paper_note
+    )
+    assert (
+        "[[PaperBot/Papers/context-distillation-for-llms|Context Distillation for LLMs]]"
+        in paper_note
+    )
     assert "[[PaperBot/Tracks/icl-compression/_MOC|ICL Compression]]" in paper_note
     assert paper_note.count("paperbot_type: paper") == 1
 
@@ -198,12 +208,9 @@ def test_export_library_snapshot_backfills_existing_cited_by_links(tmp_path: Pat
         ],
     )
 
-    prior_note = (
-        vault
-        / "PaperBot"
-        / "Papers"
-        / "2025-prior-compression-work-prior.md"
-    ).read_text(encoding="utf-8")
+    prior_note = (vault / "PaperBot" / "Papers" / "2025-prior-compression-work-prior.md").read_text(
+        encoding="utf-8"
+    )
     assert "cited_by:" in prior_note
     assert "## Cited By" in prior_note
     assert "[[PaperBot/Papers/2026-uniicl-1|UniICL]]" in prior_note
@@ -222,3 +229,102 @@ def test_export_library_snapshot_requires_existing_vault_directory(tmp_path: Pat
         assert "vault_path must be an existing directory" in str(exc)
     else:
         raise AssertionError("expected exporter to reject a missing vault directory")
+
+
+def test_export_library_snapshot_preserves_existing_personal_notes(tmp_path: Path):
+    exporter = ObsidianFilesystemExporter()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    result = exporter.export_library_snapshot(
+        vault_path=vault,
+        saved_items=[
+            {
+                "paper": {
+                    "id": "paper-1",
+                    "title": "UniICL",
+                    "abstract": "Initial summary.",
+                    "year": 2026,
+                }
+            }
+        ],
+    )
+    note_path = Path(result["paper_notes"][0])
+    note_path.write_text(
+        note_path.read_text(encoding="utf-8").rstrip()
+        + "\n\n## Personal Notes\nKeep this observation.\n",
+        encoding="utf-8",
+    )
+
+    exporter.export_library_snapshot(
+        vault_path=vault,
+        saved_items=[
+            {
+                "paper": {
+                    "id": "paper-1",
+                    "title": "UniICL",
+                    "abstract": "Updated generated summary.",
+                    "year": 2026,
+                }
+            }
+        ],
+    )
+
+    body = note_path.read_text(encoding="utf-8")
+    assert "Updated generated summary." in body
+    assert "## Personal Notes" in body
+    assert "Keep this observation." in body
+    assert "paperbot_managed_hash:" in body
+    assert "paperbot_exported_at:" in body
+
+
+def test_export_library_snapshot_writes_pending_note_when_user_edits_managed_section(
+    tmp_path: Path,
+):
+    exporter = ObsidianFilesystemExporter()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    result = exporter.export_library_snapshot(
+        vault_path=vault,
+        saved_items=[
+            {
+                "paper": {
+                    "id": "paper-1",
+                    "title": "UniICL",
+                    "abstract": "Initial summary.",
+                    "year": 2026,
+                }
+            }
+        ],
+    )
+    note_path = Path(result["paper_notes"][0])
+    original_body = note_path.read_text(encoding="utf-8")
+    note_path.write_text(
+        original_body.replace("Initial summary.", "User-edited managed summary."),
+        encoding="utf-8",
+    )
+
+    exporter.export_library_snapshot(
+        vault_path=vault,
+        saved_items=[
+            {
+                "paper": {
+                    "id": "paper-1",
+                    "title": "UniICL",
+                    "abstract": "New PaperBot summary.",
+                    "year": 2026,
+                }
+            }
+        ],
+    )
+
+    current_body = note_path.read_text(encoding="utf-8")
+    pending_path = vault / "PaperBot" / ".paperbot-pending" / "Papers" / note_path.name
+    pending_body = pending_path.read_text(encoding="utf-8")
+
+    assert "User-edited managed summary." in current_body
+    assert "New PaperBot summary." not in current_body
+    assert pending_path.exists()
+    assert "paperbot_status: pending" in pending_body
+    assert "New PaperBot summary." in pending_body

--- a/tests/unit/test_obsidian_parser.py
+++ b/tests/unit/test_obsidian_parser.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from paperbot.infrastructure.obsidian import (
+    PAPER_MANAGED_HEADINGS,
+    merge_user_sections,
+    parse_note_text,
+)
+
+
+def test_parse_note_text_extracts_user_sections_tags_and_wikilinks() -> None:
+    text = """---
+paperbot_type: paper
+tags:
+  - graph
+paperbot_managed_tags:
+  - graph
+paperbot_managed_links:
+  - PaperBot/Tracks/icl-compression/_MOC
+---
+# UniICL
+
+## Summary
+Managed summary.
+
+## Metadata
+- Venue: ICLR
+
+## Personal Notes
+Need to revisit this with #important and [[Custom/Idea|Idea]].
+
+## Open Questions
+Compare against [[PaperBot/Papers/follow-up-paper|Follow-up Paper]].
+"""
+
+    parsed = parse_note_text(text, managed_headings=PAPER_MANAGED_HEADINGS)
+
+    assert parsed.title == "UniICL"
+    assert [section.heading for section in parsed.user_sections] == [
+        "Personal Notes",
+        "Open Questions",
+    ]
+    assert parsed.user_tags == ["important"]
+    assert parsed.user_wikilinks == [
+        "Custom/Idea",
+        "PaperBot/Papers/follow-up-paper",
+    ]
+
+    merged_body = merge_user_sections(parsed.managed_body, parsed.user_sections)
+    assert "## Personal Notes" in merged_body
+    assert "## Open Questions" in merged_body

--- a/tests/unit/test_obsidian_report_routes.py
+++ b/tests/unit/test_obsidian_report_routes.py
@@ -94,3 +94,105 @@ def test_export_obsidian_report_endpoint_requires_vault_path(monkeypatch):
 
     assert response.status_code == 400
     assert "vault_path is required" in response.json()["detail"]
+
+
+class _FakeSyncResult:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def to_dict(self):
+        return dict(self._payload)
+
+
+class _FakeSyncService:
+    def __init__(self, root_path: Path):
+        self.root_path = root_path
+        self.scan_calls = 0
+
+    def get_status(self):
+        return _FakeSyncResult(
+            {
+                "last_synced_at": "2026-03-12T10:00:00+00:00",
+                "pending_count": 1,
+                "tracked_note_count": 4,
+                "conflict_count": 1,
+                "state_path": str(self.root_path / ".paperbot-sync-state.json"),
+                "pending_dir": str(self.root_path / ".paperbot-pending"),
+            }
+        )
+
+    def scan(self):
+        self.scan_calls += 1
+        return _FakeSyncResult(
+            {
+                "last_synced_at": "2026-03-12T10:05:00+00:00",
+                "scanned_notes": 4,
+                "changed_notes": 2,
+                "memories_created": 3,
+                "memories_skipped": 0,
+                "tag_updates": 1,
+                "wikilink_updates": 1,
+                "note_updates": 1,
+                "conflicts_detected": 1,
+                "pending_count": 2,
+            }
+        )
+
+    def sync_paths(self, paths):
+        return self.scan()
+
+
+class _FakeWatcher:
+    def __init__(self, *, root_path: Path, on_paths_changed, debounce_seconds: float):
+        self.root_path = root_path
+        self._on_paths_changed = on_paths_changed
+        self.debounce_seconds = debounce_seconds
+        self.is_running = False
+
+    def start(self):
+        self.is_running = True
+        return True
+
+    def stop(self):
+        self.is_running = False
+
+
+def test_obsidian_sync_routes_expose_status_scan_and_watch_controls(monkeypatch, tmp_path: Path):
+    root_path = tmp_path / "vault" / "PaperBot"
+    root_path.mkdir(parents=True)
+    fake_sync_service = _FakeSyncService(root_path)
+
+    monkeypatch.setattr(
+        obsidian_route,
+        "_build_obsidian_sync_service",
+        lambda request=None: fake_sync_service,
+    )
+    monkeypatch.setattr(
+        obsidian_route,
+        "_get_obsidian_config",
+        lambda: SimpleNamespace(sync_debounce_seconds=0.5),
+    )
+    monkeypatch.setattr(obsidian_route, "ObsidianVaultWatcher", _FakeWatcher)
+    monkeypatch.setattr(obsidian_route, "WATCHDOG_AVAILABLE", True)
+    obsidian_route._vault_watcher = None
+
+    with TestClient(app) as client:
+        status_response = client.get("/api/obsidian/sync/status")
+        scan_response = client.post("/api/obsidian/sync/scan")
+        start_response = client.post("/api/obsidian/sync/watch/start")
+        stop_response = client.post("/api/obsidian/sync/watch/stop")
+
+    assert status_response.status_code == 200
+    assert status_response.json()["tracked_note_count"] == 4
+    assert status_response.json()["watchdog_available"] is True
+
+    assert scan_response.status_code == 200
+    assert scan_response.json()["memories_created"] == 3
+
+    assert start_response.status_code == 200
+    assert start_response.json()["watching"] is True
+    assert start_response.json()["mode"] == "watchdog"
+
+    assert stop_response.status_code == 200
+    assert stop_response.json()["watching"] is False
+    assert fake_sync_service.scan_calls >= 2

--- a/tests/unit/test_obsidian_sync_service.py
+++ b/tests/unit/test_obsidian_sync_service.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from paperbot.infrastructure.event_log.memory_event_log import InMemoryEventLog
+from paperbot.infrastructure.obsidian import (
+    ObsidianBidirectionalSync,
+    PAPER_MANAGED_HEADINGS,
+    hash_markdown,
+)
+
+
+class _FakeMemoryStore:
+    def __init__(self) -> None:
+        self.memories = []
+
+    def add_memories(self, *, user_id: str, memories: list, **_: object):
+        self.memories.extend((user_id, memory) for memory in memories)
+        return len(memories), 0, []
+
+
+def test_obsidian_sync_scan_captures_user_tags_links_notes_and_conflicts(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    root = vault / "PaperBot"
+    papers_dir = root / "Papers"
+    papers_dir.mkdir(parents=True)
+
+    managed_body = """# UniICL
+
+## Summary
+Baseline summary.
+
+## Metadata
+- Venue: ICLR
+
+## Tracks
+- [[PaperBot/Tracks/icl-compression/_MOC|ICL Compression]]
+"""
+    note_path = papers_dir / "2026-uniicl-paper-1.md"
+    note_path.write_text(
+        (
+            "---\n"
+            "paperbot_type: paper\n"
+            "paperbot_id: paper-1\n"
+            "user_id: default\n"
+            "title: UniICL\n"
+            "tags:\n"
+            "  - icl\n"
+            "paperbot_managed_tags:\n"
+            "  - icl\n"
+            "paperbot_managed_links:\n"
+            "  - PaperBot/Tracks/icl-compression/_MOC\n"
+            f"paperbot_managed_hash: {hash_markdown(managed_body)}\n"
+            "---\n"
+            f"{managed_body}"
+        ),
+        encoding="utf-8",
+    )
+
+    memory_store = _FakeMemoryStore()
+    event_log = InMemoryEventLog()
+    sync_service = ObsidianBidirectionalSync(
+        vault_path=vault,
+        root_dir="PaperBot",
+        memory_store=memory_store,
+        event_log=event_log,
+    )
+
+    baseline = sync_service.scan()
+    assert baseline.changed_notes == 1
+    assert baseline.memories_created == 0
+
+    user_managed_body = """# UniICL
+
+## Summary
+User edited the managed summary.
+
+## Metadata
+- Venue: ICLR
+
+## Tracks
+- [[PaperBot/Tracks/icl-compression/_MOC|ICL Compression]]
+
+## Personal Notes
+Need to try this for #important retrieval runs.
+
+## Open Questions
+Relates to [[Custom/Prompt Compression]].
+"""
+    note_path.write_text(
+        (
+            "---\n"
+            "paperbot_type: paper\n"
+            "paperbot_id: paper-1\n"
+            "user_id: default\n"
+            "title: UniICL\n"
+            "tags:\n"
+            "  - icl\n"
+            "paperbot_managed_tags:\n"
+            "  - icl\n"
+            "paperbot_managed_links:\n"
+            "  - PaperBot/Tracks/icl-compression/_MOC\n"
+            f"paperbot_managed_hash: {hash_markdown(managed_body)}\n"
+            "---\n"
+            f"{user_managed_body}"
+        ),
+        encoding="utf-8",
+    )
+
+    result = sync_service.scan()
+    assert result.changed_notes == 1
+    assert result.memories_created == 4
+    assert result.tag_updates == 1
+    assert result.wikilink_updates == 1
+    assert result.note_updates == 1
+    assert result.conflicts_detected == 1
+
+    memory_contents = [memory.content for _, memory in memory_store.memories]
+    assert any('Obsidian tag for "UniICL": important' == content for content in memory_contents)
+    assert any(
+        'Obsidian wiki-link from "UniICL" to "Custom/Prompt Compression"' == content
+        for content in memory_contents
+    )
+    assert any(
+        'Obsidian personal note for "UniICL" (Personal Notes)' in content
+        for content in memory_contents
+    )
+
+    status = sync_service.get_status()
+    assert status.tracked_note_count == 1
+    assert status.conflict_count == 1
+    assert status.pending_count == 0
+
+    event_types = [event["type"] for event in event_log.events]
+    assert "obsidian.note.conflict_detected" in event_types

--- a/tests/unit/test_obsidian_watcher.py
+++ b/tests/unit/test_obsidian_watcher.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from paperbot.infrastructure.obsidian.watcher import DebouncedPathQueue, ObsidianVaultWatcher
+
+
+def test_debounced_path_queue_coalesces_repeated_updates() -> None:
+    now = [0.0]
+    queue = DebouncedPathQueue(debounce_seconds=1.0, time_fn=lambda: now[0])
+
+    queue.push(Path("/tmp/note.md"))
+    now[0] = 0.25
+    queue.push(Path("/tmp/note.md"))
+    now[0] = 1.0
+    assert queue.flush_ready() == []
+
+    now[0] = 1.3
+    assert queue.flush_ready() == [Path("/tmp/note.md")]
+
+
+def test_obsidian_vault_watcher_flush_pending_uses_markdown_paths_only(tmp_path: Path) -> None:
+    received = []
+    watcher = ObsidianVaultWatcher(
+        root_path=tmp_path,
+        on_paths_changed=lambda paths: received.append(paths),
+        debounce_seconds=0.1,
+    )
+
+    watcher.record_event(tmp_path / "paper.md")
+    watcher.record_event(tmp_path / "paper.md")
+    watcher.record_event(tmp_path / "paper.txt")
+
+    flushed = watcher.flush_pending()
+    assert flushed == [(tmp_path / "paper.md").resolve()]
+    assert received == [[(tmp_path / "paper.md").resolve()]]

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -47,6 +47,10 @@ def test_from_dict_loads_obsidian_section() -> None:
                 "vault_path": "/tmp/vault",
                 "root_dir": "Research Notes",
                 "paper_template_path": "/tmp/paper.md.j2",
+                "sync_state_filename": ".sync-state.json",
+                "pending_dirname": ".pending",
+                "sync_debounce_seconds": 2.5,
+                "auto_watch": True,
             }
         }
     )
@@ -55,6 +59,10 @@ def test_from_dict_loads_obsidian_section() -> None:
     assert settings.obsidian.vault_path == "/tmp/vault"
     assert settings.obsidian.root_dir == "Research Notes"
     assert settings.obsidian.paper_template_path == "/tmp/paper.md.j2"
+    assert settings.obsidian.sync_state_filename == ".sync-state.json"
+    assert settings.obsidian.pending_dirname == ".pending"
+    assert settings.obsidian.sync_debounce_seconds == 2.5
+    assert settings.obsidian.auto_watch is True
 
 
 def test_load_from_file_merges_partial_nested_dicts(tmp_path: Path) -> None:
@@ -112,6 +120,10 @@ def test_load_environment_variables_overrides_obsidian(monkeypatch: pytest.Monke
     monkeypatch.setenv("PAPERBOT_OBSIDIAN_AUTO_EXPORT", "false")
     monkeypatch.setenv("PAPERBOT_OBSIDIAN_AUTO_SYNC_TRACKS", "false")
     monkeypatch.setenv("PAPERBOT_OBSIDIAN_EXPORT_LIMIT", "42")
+    monkeypatch.setenv("PAPERBOT_OBSIDIAN_SYNC_STATE_FILE", ".sync-state.json")
+    monkeypatch.setenv("PAPERBOT_OBSIDIAN_PENDING_DIRNAME", ".pending")
+    monkeypatch.setenv("PAPERBOT_OBSIDIAN_SYNC_DEBOUNCE_SECONDS", "2.5")
+    monkeypatch.setenv("PAPERBOT_OBSIDIAN_AUTO_WATCH", "true")
 
     settings.load_environment_variables()
 
@@ -122,6 +134,10 @@ def test_load_environment_variables_overrides_obsidian(monkeypatch: pytest.Monke
     assert settings.obsidian.auto_export_on_save is False
     assert settings.obsidian.auto_sync_tracks is False
     assert settings.obsidian.export_limit == 42
+    assert settings.obsidian.sync_state_filename == ".sync-state.json"
+    assert settings.obsidian.pending_dirname == ".pending"
+    assert settings.obsidian.sync_debounce_seconds == 2.5
+    assert settings.obsidian.auto_watch is True
 
 
 def test_load_environment_variables_warns_on_invalid_obsidian_export_limit(


### PR DESCRIPTION
## Summary
- add an Obsidian bidirectional sync package with markdown parsing, conflict detection, stateful scans, and optional watchdog-based watching
- preserve user-managed note sections during export and write PaperBot updates into `.paperbot-pending` when managed sections were edited manually
- expose sync status/scan/watch API routes and extend settings/dependencies for sync state, debounce, and pending configuration

## Validation
- `pytest -q tests/unit/test_obsidian*.py tests/unit/test_settings.py`
- `pytest -q tests/unit/test_obsidian_parser.py tests/unit/test_obsidian_exporter.py tests/unit/test_obsidian_sync_service.py tests/unit/test_obsidian_watcher.py tests/unit/test_obsidian_report_routes.py tests/unit/test_settings.py`

## Linked Issue
- refs #173