### PR TITLE
feat(openclaw): add paperbot plugin bridge

### DIFF
--- a/openclaw/paperbot-openclaw/.gitignore
+++ b/openclaw/paperbot-openclaw/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/openclaw/paperbot-openclaw/README.md
+++ b/openclaw/paperbot-openclaw/README.md
@@ -1,0 +1,39 @@
+# paperbot-openclaw
+
+Thin OpenClaw plugin package that bridges PaperBot's FastAPI backend into:
+
+- `registerTool`: `paper_search`, `paper_analyze`, `paper_track`, `gen_code`, `review`, `research`
+- `registerHook`: message intent routing and prompt context injection
+- `registerCli`: `openclaw paper search|analyze|track|gen-code`
+- cron descriptors for `paper-monitor`, `weekly-digest`, `conference-deadlines`, `citation-monitor`
+
+## Configuration
+
+```json
+{
+  "baseUrl": "http://127.0.0.1:8000",
+  "authToken": "",
+  "defaultUserId": "default",
+  "requestTimeoutMs": 30000,
+  "contextTrackId": 0,
+  "defaultSearchSources": ["papers_cool"],
+  "defaultSearchBranches": ["arxiv", "venue"],
+  "enableContextInjection": true,
+  "cronQueries": ["llm agents", "retrieval augmented generation"],
+  "cronScholarId": ""
+}
+```
+
+## API Mapping
+
+- `paper_search` -> `POST /api/research/paperscool/search`
+- `paper_analyze` -> `POST /api/analyze`
+- `paper_track` -> `GET /api/track`
+- `gen_code` -> `POST /api/gen-code`
+- `review` -> `POST /api/review`
+- `research` -> `POST /api/research/context`
+
+## Cron Descriptors
+
+The package exports `DEFAULT_PAPERBOT_CRON_JOBS` so OpenClaw runtime wiring can
+map them into its own cron system without hard-coding schedules elsewhere.

--- a/openclaw/paperbot-openclaw/package-lock.json
+++ b/openclaw/paperbot-openclaw/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "paperbot-openclaw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "paperbot-openclaw",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/openclaw/paperbot-openclaw/package.json
+++ b/openclaw/paperbot-openclaw/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "paperbot-openclaw",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "OpenClaw plugin shim that bridges PaperBot FastAPI capabilities into OpenClaw tools, hooks, CLI, and cron descriptors.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "test": "npm run build && node --test test/plugin.test.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/openclaw/paperbot-openclaw/src/cron.ts
+++ b/openclaw/paperbot-openclaw/src/cron.ts
@@ -1,0 +1,55 @@
+import type { CronJobDefinition, PaperBotOpenClawConfig } from "./types.js";
+
+export const DEFAULT_PAPERBOT_CRON_JOBS: CronJobDefinition[] = [
+  {
+    id: "paper-monitor",
+    expression: "0 6 * * *",
+    description: "Run scholar tracking through PaperBot every morning.",
+    task: "paper-monitor",
+    defaultInput: { scholarId: "", maxNewPapers: 5 }
+  },
+  {
+    id: "weekly-digest",
+    expression: "0 9 * * 1",
+    description: "Build a weekly PaperBot digest using the configured research queries.",
+    task: "weekly-digest",
+    defaultInput: { queries: [] }
+  },
+  {
+    id: "conference-deadlines",
+    expression: "0 8 * * *",
+    description: "Fetch the latest deadline radar for configured tracks.",
+    task: "conference-deadlines",
+    defaultInput: {}
+  },
+  {
+    id: "citation-monitor",
+    expression: "0 * * * *",
+    description: "Poll PaperBot for citation milestones based on stored cron queries.",
+    task: "citation-monitor",
+    defaultInput: { queries: [] }
+  }
+];
+
+export function resolveCronJobs(config: PaperBotOpenClawConfig): CronJobDefinition[] {
+  return DEFAULT_PAPERBOT_CRON_JOBS.map((job) => {
+    if (job.task === "paper-monitor") {
+      return {
+        ...job,
+        defaultInput: {
+          scholarId: config.cronScholarId ?? "",
+          maxNewPapers: 5
+        }
+      };
+    }
+    if (job.task === "weekly-digest" || job.task === "citation-monitor") {
+      return {
+        ...job,
+        defaultInput: {
+          queries: [...config.cronQueries]
+        }
+      };
+    }
+    return job;
+  });
+}

--- a/openclaw/paperbot-openclaw/src/index.ts
+++ b/openclaw/paperbot-openclaw/src/index.ts
@@ -1,0 +1,364 @@
+import type {
+  BeforePromptBuildEvent,
+  BeforePromptBuildResult,
+  OpenClawPluginApi,
+  ToolDefinition,
+  ToolResult
+} from "openclaw/plugin-sdk/core";
+
+import { DEFAULT_PAPERBOT_CRON_JOBS, resolveCronJobs } from "./cron.js";
+import { detectPaperIntent, latestUserMessage } from "./intents.js";
+import { createPaperBotClient } from "./paperbot-client.js";
+import type {
+  FetchLike,
+  GenCodeInput,
+  PaperAnalyzeInput,
+  PaperSearchInput,
+  PaperTrackInput,
+  ResearchInput,
+  ReviewInput
+} from "./types.js";
+import { normalizeConfig } from "./types.js";
+
+function textResult(payload: unknown): ToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(payload, null, 2)
+      }
+    ]
+  };
+}
+
+function toolErrorResult(error: unknown): ToolResult {
+  return textResult({
+    ok: false,
+    error: error instanceof Error ? error.message : String(error)
+  });
+}
+
+function createTool<TInput extends object>(
+  name: string,
+  description: string,
+  parameters: Record<string, unknown>,
+  execute: (input: TInput) => Promise<unknown>
+): ToolDefinition<TInput> {
+  return {
+    name,
+    description,
+    parameters,
+    async execute(_invocationId: string, input: TInput): Promise<ToolResult> {
+      try {
+        const payload = await execute(input);
+        return textResult(payload);
+      } catch (error) {
+        return toolErrorResult(error);
+      }
+    }
+  };
+}
+
+function summarizeResearchContext(payload: unknown): string {
+  const context = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const memories = Array.isArray(context.memory_items) ? context.memory_items.length : 0;
+  const papers = Array.isArray(context.paper_recommendations)
+    ? context.paper_recommendations.length
+    : 0;
+  return [
+    "PaperBot context bridge:",
+    `- memories: ${memories}`,
+    `- paper recommendations: ${papers}`,
+    `- raw payload: ${JSON.stringify(context)}`
+  ].join("\n");
+}
+
+export function createPaperBotOpenClawPlugin(options: { fetchImpl?: FetchLike } = {}) {
+  return {
+    id: "paperbot-openclaw",
+    name: "paperbot-openclaw",
+    version: "0.1.0",
+    async register(api: OpenClawPluginApi): Promise<void> {
+      const config = normalizeConfig(api.config);
+      const client = createPaperBotClient(config, options.fetchImpl);
+
+      api.registerTool(
+        createTool<PaperSearchInput>(
+          "paper_search",
+          "Run multi-source paper discovery through PaperBot.",
+          {
+            type: "object",
+            properties: {
+              query: { type: "string", minLength: 1 },
+              sources: { type: "array", items: { type: "string" } },
+              branches: { type: "array", items: { type: "string" } },
+              topKPerQuery: { type: "integer", minimum: 1, maximum: 50 },
+              showPerBranch: { type: "integer", minimum: 1, maximum: 200 },
+              minScore: { type: "number", minimum: 0 }
+            },
+            required: ["query"],
+            additionalProperties: false
+          },
+          async (input: PaperSearchInput) => client.searchPapers(input)
+        )
+      );
+
+      api.registerTool(
+        createTool<PaperAnalyzeInput>(
+          "paper_analyze",
+          "Stream PaperBot paper analysis and return the final result event.",
+          {
+            type: "object",
+            properties: {
+              title: { type: "string", minLength: 1 },
+              abstract: { type: "string" },
+              doi: { type: "string" }
+            },
+            required: ["title"],
+            additionalProperties: false
+          },
+          async (input: PaperAnalyzeInput) => client.analyzePaper(input)
+        )
+      );
+
+      api.registerTool(
+        createTool<PaperTrackInput>(
+          "paper_track",
+          "Track a scholar through PaperBot and return the latest tracking summary.",
+          {
+            type: "object",
+            properties: {
+              scholarId: { type: "string" },
+              scholarName: { type: "string" },
+              force: { type: "boolean" },
+              dryRun: { type: "boolean" },
+              maxNewPapers: { type: "integer", minimum: 1, maximum: 20 }
+            },
+            additionalProperties: false
+          },
+          async (input: PaperTrackInput) => client.trackScholar(input)
+        )
+      );
+
+      api.registerTool(
+        createTool<GenCodeInput>(
+          "gen_code",
+          "Run Paper2Code generation and return the final generation payload.",
+          {
+            type: "object",
+            properties: {
+              title: { type: "string", minLength: 1 },
+              abstract: { type: "string", minLength: 1 },
+              methodSection: { type: "string" },
+              userId: { type: "string" }
+            },
+            required: ["title", "abstract"],
+            additionalProperties: false
+          },
+          async (input: GenCodeInput) => client.generateCode(input)
+        )
+      );
+
+      api.registerTool(
+        createTool<ReviewInput>(
+          "review",
+          "Run PaperBot's deep review flow and return the review result.",
+          {
+            type: "object",
+            properties: {
+              title: { type: "string", minLength: 1 },
+              abstract: { type: "string", minLength: 1 }
+            },
+            required: ["title", "abstract"],
+            additionalProperties: false
+          },
+          async (input: ReviewInput) => client.reviewPaper(input)
+        )
+      );
+
+      api.registerTool(
+        createTool<ResearchInput>(
+          "research",
+          "Build a research context pack for the current query.",
+          {
+            type: "object",
+            properties: {
+              query: { type: "string", minLength: 1 },
+              userId: { type: "string" },
+              trackId: { type: "integer", minimum: 1 },
+              personalized: { type: "boolean" },
+              paperLimit: { type: "integer", minimum: 1, maximum: 20 },
+              memoryLimit: { type: "integer", minimum: 1, maximum: 20 }
+            },
+            required: ["query"],
+            additionalProperties: false
+          },
+          async (input: ResearchInput) => client.buildResearchContext(input)
+        )
+      );
+
+      const messageHook = async (payload: unknown) => {
+        const content = extractHookText(payload);
+        const suggestedTool = detectPaperIntent(content);
+        if (!suggestedTool) {
+          return null;
+        }
+        return {
+          suggestedTool,
+          confidence: 0.7,
+          reason: `matched PaperBot intent in message: ${content.slice(0, 80)}`
+        };
+      };
+
+      api.registerHook("msg_recv", messageHook, {
+        name: "paperbot-msg-router",
+        description: "Map paper-related user messages to the right PaperBot tool."
+      });
+      api.registerHook("message_received", messageHook, {
+        name: "paperbot-message-router",
+        description: "OpenClaw runtime hook alias for PaperBot message routing."
+      });
+
+      const beforePromptHook = async (
+        event: BeforePromptBuildEvent
+      ): Promise<BeforePromptBuildResult> => {
+        if (!config.enableContextInjection) {
+          return {};
+        }
+        const query = latestUserMessage(event.messages);
+        if (!query || !detectPaperIntent(query)) {
+          return {};
+        }
+        try {
+          const context = await client.buildResearchContext({
+            query,
+            userId: config.defaultUserId,
+            trackId: config.contextTrackId,
+            personalized: true,
+            paperLimit: 5,
+            memoryLimit: 8
+          });
+          return {
+            prependSystemContext: summarizeResearchContext(context)
+          };
+        } catch (error) {
+          api.logger.warn("paperbot-openclaw context injection skipped", error);
+          return {};
+        }
+      };
+
+      api.registerHook(
+        "before_prompt",
+        async (payload) =>
+          beforePromptHook({
+            messages:
+              payload && typeof payload === "object" && "messages" in payload
+                ? ((payload as { messages?: BeforePromptBuildEvent["messages"] }).messages ?? [])
+                : []
+          }),
+        {
+          name: "paperbot-before-prompt",
+          description: "Inject compact research context from PaperBot before prompt construction."
+        }
+      );
+      api.on("before_prompt_build", beforePromptHook, { priority: 20 });
+
+      api.registerCli(
+        ({ program }) => {
+          const paper = program.command("paper").description("PaperBot bridge commands");
+
+          paper
+            .command("search")
+            .description("Search papers through PaperBot")
+            .option("--query <query>", "Search query")
+            .action(async (options) => {
+              const payload = await client.searchPapers({
+                query: String(options.query ?? "")
+              });
+              console.log(JSON.stringify(payload, null, 2));
+            });
+
+          paper
+            .command("analyze")
+            .description("Analyze a paper through PaperBot")
+            .option("--title <title>", "Paper title")
+            .option("--abstract <abstract>", "Paper abstract")
+            .action(async (options) => {
+              const payload = await client.analyzePaper({
+                title: String(options.title ?? ""),
+                abstract: String(options.abstract ?? "")
+              });
+              console.log(JSON.stringify(payload, null, 2));
+            });
+
+          paper
+            .command("track")
+            .description("Track a scholar through PaperBot")
+            .option("--scholar-id <scholarId>", "Semantic Scholar author id")
+            .option("--scholar-name <scholarName>", "Scholar display name")
+            .action(async (options) => {
+              const payload = await client.trackScholar({
+                scholarId: asOptionalString(options.scholarId),
+                scholarName: asOptionalString(options.scholarName)
+              });
+              console.log(JSON.stringify(payload, null, 2));
+            });
+
+          paper
+            .command("gen-code")
+            .description("Run Paper2Code through PaperBot")
+            .option("--title <title>", "Paper title")
+            .option("--abstract <abstract>", "Paper abstract")
+            .action(async (options) => {
+              const payload = await client.generateCode({
+                title: String(options.title ?? ""),
+                abstract: String(options.abstract ?? ""),
+                userId: config.defaultUserId
+              });
+              console.log(JSON.stringify(payload, null, 2));
+            });
+        },
+        { commands: ["paper"] }
+      );
+
+      const cronJobs = resolveCronJobs(config);
+      api.registerService({
+        id: "paperbot-openclaw-cron",
+        async start() {
+          api.logger.info("paperbot-openclaw cron jobs ready", cronJobs);
+          return { cronJobs };
+        },
+        async stop() {
+          api.logger.info("paperbot-openclaw cron service stopped");
+        }
+      });
+    }
+  };
+}
+
+export const DEFAULT_PAPERBOT_PLUGIN = createPaperBotOpenClawPlugin();
+export { DEFAULT_PAPERBOT_CRON_JOBS } from "./cron.js";
+export { createPaperBotClient, normalizeConfig } from "./paperbot-client.js";
+export default DEFAULT_PAPERBOT_PLUGIN;
+
+function extractHookText(payload: unknown): string {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+  if ("text" in payload) {
+    return String((payload as { text?: unknown }).text ?? "").trim();
+  }
+  if ("content" in payload) {
+    return String((payload as { content?: unknown }).content ?? "").trim();
+  }
+  if ("messages" in payload) {
+    const messages = (payload as { messages?: BeforePromptBuildEvent["messages"] }).messages;
+    return latestUserMessage(messages ?? []);
+  }
+  return "";
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  const normalized = String(value ?? "").trim();
+  return normalized || undefined;
+}

--- a/openclaw/paperbot-openclaw/src/intents.ts
+++ b/openclaw/paperbot-openclaw/src/intents.ts
@@ -1,0 +1,29 @@
+const INTENT_PATTERNS: Array<[string, RegExp]> = [
+  ["gen_code", /\b(code|implement|reproduce|replicate|prototype)\b/i],
+  ["review", /\b(review|critique|weakness|accept|reject)\b/i],
+  ["paper_track", /\b(track|scholar|author monitor|new papers)\b/i],
+  ["paper_analyze", /\b(analyze|analysis|summarize|summary|contribution)\b/i],
+  ["research", /\b(context|related work|research plan|literature)\b/i],
+  ["paper_search", /\b(find|search|papers?|survey|retrieve)\b/i]
+];
+
+export function detectPaperIntent(text: string): string | null {
+  const normalized = String(text ?? "").trim();
+  if (!normalized) {
+    return null;
+  }
+  for (const [toolName, pattern] of INTENT_PATTERNS) {
+    if (pattern.test(normalized)) {
+      return toolName;
+    }
+  }
+  return null;
+}
+
+export function latestUserMessage(messages: Array<{ role?: string; content?: string }> | undefined): string {
+  if (!Array.isArray(messages)) {
+    return "";
+  }
+  const lastUser = [...messages].reverse().find((message) => message.role === "user");
+  return String(lastUser?.content ?? "").trim();
+}

--- a/openclaw/paperbot-openclaw/src/openclaw-sdk.d.ts
+++ b/openclaw/paperbot-openclaw/src/openclaw-sdk.d.ts
@@ -1,0 +1,82 @@
+declare module "openclaw/plugin-sdk/core" {
+  export interface ToolTextChunk {
+    type: "text";
+    text: string;
+  }
+
+  export interface ToolResult {
+    content: ToolTextChunk[];
+  }
+
+  export interface ToolDefinition<TInput = Record<string, unknown>> {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    execute(invocationId: string, input: TInput): Promise<ToolResult>;
+  }
+
+  export interface HookRegistrationOptions {
+    name: string;
+    description?: string;
+  }
+
+  export interface PromptMessage {
+    role?: string;
+    content?: string;
+  }
+
+  export interface BeforePromptBuildEvent {
+    messages?: PromptMessage[];
+  }
+
+  export interface BeforePromptBuildResult {
+    prependSystemContext?: string;
+  }
+
+  export interface CommandBuilder {
+    description(text: string): CommandBuilder;
+    option(flags: string, description?: string): CommandBuilder;
+    action(handler: (options: Record<string, unknown>) => unknown | Promise<unknown>): CommandBuilder;
+    command(name: string): CommandBuilder;
+  }
+
+  export interface CommandProgram {
+    command(name: string): CommandBuilder;
+  }
+
+  export interface LoggerLike {
+    info(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+    error(...args: unknown[]): void;
+  }
+
+  export interface ServiceRegistration {
+    id: string;
+    start(): unknown | Promise<unknown>;
+    stop(): unknown | Promise<unknown>;
+  }
+
+  export interface OpenClawPluginApi {
+    config?: unknown;
+    logger: LoggerLike;
+    registerTool<TInput = Record<string, unknown>>(tool: ToolDefinition<TInput>): void;
+    registerHook(
+      name: string,
+      handler: (payload: unknown, context?: unknown) => unknown | Promise<unknown>,
+      options?: HookRegistrationOptions
+    ): void;
+    on(
+      name: "before_prompt_build",
+      handler: (
+        event: BeforePromptBuildEvent,
+        context?: unknown
+      ) => BeforePromptBuildResult | Promise<BeforePromptBuildResult>,
+      options?: { priority?: number }
+    ): void;
+    registerCli(
+      register: (ctx: { program: CommandProgram }) => void,
+      options?: { commands?: string[] }
+    ): void;
+    registerService(service: ServiceRegistration): void;
+  }
+}

--- a/openclaw/paperbot-openclaw/src/paperbot-client.ts
+++ b/openclaw/paperbot-openclaw/src/paperbot-client.ts
@@ -1,0 +1,226 @@
+import type {
+  FetchLike,
+  GenCodeInput,
+  PaperAnalyzeInput,
+  PaperBotOpenClawConfig,
+  PaperSearchInput,
+  PaperTrackInput,
+  ResearchInput,
+  ReviewInput,
+  SseCollectionResult
+} from "./types.js";
+import { normalizeConfig } from "./types.js";
+
+export { normalizeConfig } from "./types.js";
+
+export class PaperBotClient {
+  private readonly config: PaperBotOpenClawConfig;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(config: PaperBotOpenClawConfig, fetchImpl: FetchLike = fetch) {
+    this.config = config;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async searchPapers(input: PaperSearchInput): Promise<unknown> {
+    return this.requestJson("/api/research/paperscool/search", {
+      method: "POST",
+      body: JSON.stringify({
+        queries: [input.query],
+        sources: input.sources ?? this.config.defaultSearchSources,
+        branches: input.branches ?? this.config.defaultSearchBranches,
+        top_k_per_query: input.topKPerQuery ?? 5,
+        show_per_branch: input.showPerBranch ?? 25,
+        min_score: input.minScore ?? 0
+      })
+    });
+  }
+
+  async analyzePaper(input: PaperAnalyzeInput): Promise<unknown> {
+    const response = await this.requestSse("/api/analyze", {
+      method: "POST",
+      body: JSON.stringify({
+        title: input.title,
+        abstract: input.abstract ?? "",
+        doi: input.doi ?? null
+      })
+    });
+    return response.result ?? response.progress.at(-1) ?? {};
+  }
+
+  async trackScholar(input: PaperTrackInput): Promise<unknown> {
+    const params = new URLSearchParams();
+    if (input.scholarId) {
+      params.set("scholar_id", input.scholarId);
+    }
+    if (input.scholarName) {
+      params.set("scholar_name", input.scholarName);
+    }
+    if (input.force) {
+      params.set("force", "true");
+    }
+    if (input.dryRun) {
+      params.set("dry_run", "true");
+    }
+    params.set("max_new_papers", String(input.maxNewPapers ?? 5));
+    const response = await this.requestSse(`/api/track?${params.toString()}`, {
+      method: "GET"
+    });
+    return response.result ?? response.progress.at(-1) ?? {};
+  }
+
+  async generateCode(input: GenCodeInput): Promise<unknown> {
+    const response = await this.requestSse("/api/gen-code", {
+      method: "POST",
+      body: JSON.stringify({
+        user_id: input.userId ?? this.config.defaultUserId,
+        title: input.title,
+        abstract: input.abstract,
+        method_section: input.methodSection ?? null
+      })
+    });
+    return response.result ?? response.progress.at(-1) ?? {};
+  }
+
+  async reviewPaper(input: ReviewInput): Promise<unknown> {
+    const response = await this.requestSse("/api/review", {
+      method: "POST",
+      body: JSON.stringify(input)
+    });
+    return response.result ?? response.progress.at(-1) ?? {};
+  }
+
+  async buildResearchContext(input: ResearchInput): Promise<unknown> {
+    return this.requestJson("/api/research/context", {
+      method: "POST",
+      body: JSON.stringify({
+        query: input.query,
+        user_id: input.userId ?? this.config.defaultUserId,
+        track_id: input.trackId ?? this.config.contextTrackId ?? null,
+        personalized: input.personalized ?? true,
+        paper_limit: input.paperLimit ?? 5,
+        memory_limit: input.memoryLimit ?? 8
+      })
+    });
+  }
+
+  async buildWeeklyDigest(input: { queries: string[] }): Promise<unknown> {
+    return this.requestJson("/api/research/paperscool/daily", {
+      method: "POST",
+      body: JSON.stringify({
+        queries: input.queries,
+        notify: false,
+        save: false
+      })
+    });
+  }
+
+  async getDeadlineRadar(): Promise<unknown> {
+    return this.requestJson("/api/research/deadlines/radar", {
+      method: "GET"
+    });
+  }
+
+  async monitorCitationMilestones(input: { queries: string[] }): Promise<unknown> {
+    return this.requestJson("/api/papers/search", {
+      method: "POST",
+      body: JSON.stringify({
+        query: input.queries.join(" "),
+        limit: 10,
+        sort_by: "citation_count",
+        sort_order: "desc"
+      })
+    });
+  }
+
+  private async requestJson(path: string, init: RequestInit): Promise<unknown> {
+    const response = await this.fetchWithTimeout(path, init);
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(text || `PaperBot request failed with ${response.status}`);
+    }
+    return text ? JSON.parse(text) : {};
+  }
+
+  private async requestSse(path: string, init: RequestInit): Promise<SseCollectionResult> {
+    const response = await this.fetchWithTimeout(path, init);
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(text || `PaperBot SSE request failed with ${response.status}`);
+    }
+    return collectSseResult(text);
+  }
+
+  private async fetchWithTimeout(path: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.config.requestTimeoutMs);
+    try {
+      return await this.fetchImpl(`${this.config.baseUrl}${path}`, {
+        ...init,
+        headers: {
+          "content-type": "application/json",
+          ...authHeaders(this.config),
+          ...(init.headers ?? {})
+        },
+        signal: controller.signal
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export function createPaperBotClient(
+  rawConfig: unknown,
+  fetchImpl: FetchLike = fetch
+): PaperBotClient {
+  return new PaperBotClient(normalizeConfig(rawConfig), fetchImpl);
+}
+
+export function collectSseResult(text: string): SseCollectionResult {
+  const progress: Array<Record<string, unknown>> = [];
+  let result: unknown = null;
+
+  for (const chunk of text.split(/\n\n+/)) {
+    const trimmed = chunk.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const dataLines = trimmed
+      .split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim());
+    for (const dataLine of dataLines) {
+      if (!dataLine || dataLine === "[DONE]") {
+        continue;
+      }
+      const payload = JSON.parse(dataLine) as {
+        type?: string;
+        data?: Record<string, unknown>;
+        message?: string;
+      };
+      if (payload.type === "error") {
+        throw new Error(payload.message ?? "PaperBot SSE stream failed");
+      }
+      if (payload.type === "result") {
+        result = payload.data ?? {};
+      } else if (payload.data && typeof payload.data === "object") {
+        progress.push(payload.data);
+      }
+    }
+  }
+
+  return {
+    result: (result as Record<string, unknown> | null) ?? null,
+    progress
+  };
+}
+
+function authHeaders(config: PaperBotOpenClawConfig): HeadersInit {
+  if (!config.authToken) {
+    return {};
+  }
+  return {
+    authorization: `Bearer ${config.authToken}`
+  };
+}

--- a/openclaw/paperbot-openclaw/src/types.ts
+++ b/openclaw/paperbot-openclaw/src/types.ts
@@ -1,0 +1,99 @@
+export interface PaperBotOpenClawConfig {
+  baseUrl: string;
+  authToken?: string;
+  defaultUserId: string;
+  requestTimeoutMs: number;
+  contextTrackId?: number;
+  defaultSearchSources: string[];
+  defaultSearchBranches: string[];
+  enableContextInjection: boolean;
+  cronQueries: string[];
+  cronScholarId?: string;
+}
+
+export interface CronJobDefinition {
+  id: string;
+  expression: string;
+  description: string;
+  task: "paper-monitor" | "weekly-digest" | "conference-deadlines" | "citation-monitor";
+  defaultInput: Record<string, unknown>;
+}
+
+export interface PaperSearchInput {
+  query: string;
+  sources?: string[];
+  branches?: string[];
+  topKPerQuery?: number;
+  showPerBranch?: number;
+  minScore?: number;
+}
+
+export interface PaperAnalyzeInput {
+  title: string;
+  abstract?: string;
+  doi?: string;
+}
+
+export interface PaperTrackInput {
+  scholarId?: string;
+  scholarName?: string;
+  force?: boolean;
+  dryRun?: boolean;
+  maxNewPapers?: number;
+}
+
+export interface GenCodeInput {
+  title: string;
+  abstract: string;
+  methodSection?: string;
+  userId?: string;
+}
+
+export interface ReviewInput {
+  title: string;
+  abstract: string;
+}
+
+export interface ResearchInput {
+  query: string;
+  userId?: string;
+  trackId?: number;
+  personalized?: boolean;
+  paperLimit?: number;
+  memoryLimit?: number;
+}
+
+export interface SseCollectionResult<TData = unknown> {
+  result: TData | null;
+  progress: Array<Record<string, unknown>>;
+}
+
+export type FetchLike = typeof fetch;
+
+export function normalizeConfig(rawConfig: unknown): PaperBotOpenClawConfig {
+  const config = rawConfig && typeof rawConfig === "object" ? (rawConfig as Record<string, unknown>) : {};
+
+  return {
+    baseUrl: String(config.baseUrl ?? "http://127.0.0.1:8000").replace(/\/+$/, ""),
+    authToken: String(config.authToken ?? "").trim() || undefined,
+    defaultUserId: String(config.defaultUserId ?? "default").trim() || "default",
+    requestTimeoutMs: Math.max(1000, Number(config.requestTimeoutMs ?? 30000)),
+    contextTrackId:
+      config.contextTrackId === undefined || config.contextTrackId === null
+        ? undefined
+        : Number(config.contextTrackId),
+    defaultSearchSources: toStringList(config.defaultSearchSources, ["papers_cool"]),
+    defaultSearchBranches: toStringList(config.defaultSearchBranches, ["arxiv", "venue"]),
+    enableContextInjection: config.enableContextInjection !== false,
+    cronQueries: toStringList(config.cronQueries, ["llm agents"]),
+    cronScholarId: String(config.cronScholarId ?? "").trim() || undefined
+  };
+}
+
+function toStringList(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) {
+    return [...fallback];
+  }
+  const items = value.map((item) => String(item ?? "").trim()).filter(Boolean);
+  return items.length > 0 ? items : [...fallback];
+}

--- a/openclaw/paperbot-openclaw/test/plugin.test.js
+++ b/openclaw/paperbot-openclaw/test/plugin.test.js
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import plugin, {
+  DEFAULT_PAPERBOT_CRON_JOBS,
+  createPaperBotOpenClawPlugin
+} from "../dist/index.js";
+
+function createMockProgram(registry) {
+  function createCommand(path) {
+    return {
+      description() {
+        return this;
+      },
+      option() {
+        return this;
+      },
+      action(handler) {
+        registry.push({ path, handler });
+        return this;
+      },
+      command(name) {
+        return createCommand(`${path} ${name}`);
+      }
+    };
+  }
+
+  return {
+    command(name) {
+      return createCommand(name);
+    }
+  };
+}
+
+function createMockApi(config = {}) {
+  const tools = [];
+  const hooks = [];
+  const lifecycleHooks = [];
+  const cliCommands = [];
+  const services = [];
+  const logs = [];
+
+  return {
+    api: {
+      config,
+      logger: {
+        info(...args) {
+          logs.push(["info", ...args]);
+        },
+        warn(...args) {
+          logs.push(["warn", ...args]);
+        },
+        error(...args) {
+          logs.push(["error", ...args]);
+        }
+      },
+      registerTool(tool) {
+        tools.push(tool);
+      },
+      registerHook(name, handler, options) {
+        hooks.push({ name, handler, options });
+      },
+      on(name, handler, options) {
+        lifecycleHooks.push({ name, handler, options });
+      },
+      registerCli(register, options) {
+        const registry = [];
+        register({ program: createMockProgram(registry) });
+        cliCommands.push({ options, registry });
+      },
+      registerService(service) {
+        services.push(service);
+      }
+    },
+    tools,
+    hooks,
+    lifecycleHooks,
+    cliCommands,
+    services,
+    logs
+  };
+}
+
+test("default export exposes the paperbot-openclaw plugin descriptor", () => {
+  assert.equal(plugin.id, "paperbot-openclaw");
+  assert.equal(plugin.name, "paperbot-openclaw");
+});
+
+test("register wires tools, hooks, cli commands, and cron-backed service", async () => {
+  const fetchCalls = [];
+  const mockFetch = async (url, init) => {
+    fetchCalls.push([url, init]);
+    return new Response(JSON.stringify({ ok: true, items: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  };
+  const mock = createMockApi({
+    baseUrl: "http://paperbot.local",
+    defaultUserId: "openclaw-user",
+    cronQueries: ["llm agents", "prompt compression"]
+  });
+
+  await createPaperBotOpenClawPlugin({ fetchImpl: mockFetch }).register(mock.api);
+
+  assert.equal(mock.tools.length, 6);
+  assert.deepEqual(
+    mock.tools.map((tool) => tool.name).sort(),
+    ["gen_code", "paper_analyze", "paper_search", "paper_track", "research", "review"]
+  );
+  assert.deepEqual(
+    mock.hooks.map((hook) => hook.name).sort(),
+    ["before_prompt", "message_received", "msg_recv"]
+  );
+  assert.deepEqual(
+    mock.lifecycleHooks.map((hook) => hook.name),
+    ["before_prompt_build"]
+  );
+  assert.equal(mock.cliCommands.length, 1);
+  assert.deepEqual(
+    mock.cliCommands[0].registry.map((row) => row.path).sort(),
+    ["paper analyze", "paper gen-code", "paper search", "paper track"]
+  );
+  assert.equal(mock.services.length, 1);
+  const servicePayload = await mock.services[0].start();
+  assert.equal(servicePayload.cronJobs.length, 4);
+  assert.equal(fetchCalls.length, 0);
+});
+
+test("paper_search tool bridges to PaperBot paperscool search", async () => {
+  const mock = createMockApi({ baseUrl: "http://paperbot.local" });
+  const fetchCalls = [];
+  const mockFetch = async (url, init) => {
+    fetchCalls.push([url, init]);
+    return new Response(
+      JSON.stringify({
+        source: "papers_cool",
+        queries: [],
+        items: [{ title: "UniICL" }],
+        summary: { total: 1 }
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      }
+    );
+  };
+
+  await createPaperBotOpenClawPlugin({ fetchImpl: mockFetch }).register(mock.api);
+  const tool = mock.tools.find((item) => item.name === "paper_search");
+
+  const result = await tool.execute("tool-1", { query: "llm agents" });
+
+  assert.equal(fetchCalls[0][0], "http://paperbot.local/api/research/paperscool/search");
+  assert.match(result.content[0].text, /UniICL/);
+});
+
+test("SSE-backed tools return the final result envelope", async () => {
+  const mock = createMockApi({ baseUrl: "http://paperbot.local" });
+  const mockFetch = async () =>
+    new Response(
+      [
+        'data: {"type":"progress","data":{"phase":"Initializing"}}',
+        "",
+        'data: {"type":"result","data":{"summary":"analysis complete","score":0.9}}',
+        "",
+        "data: [DONE]",
+        ""
+      ].join("\n"),
+      {
+        status: 200,
+        headers: { "content-type": "text/event-stream" }
+      }
+    );
+
+  await createPaperBotOpenClawPlugin({ fetchImpl: mockFetch }).register(mock.api);
+  const analyzeTool = mock.tools.find((item) => item.name === "paper_analyze");
+  const reviewTool = mock.tools.find((item) => item.name === "review");
+
+  const analyzeResult = await analyzeTool.execute("tool-2", { title: "UniICL" });
+  const reviewResult = await reviewTool.execute("tool-3", {
+    title: "UniICL",
+    abstract: "A paper about in-context learning."
+  });
+
+  assert.match(analyzeResult.content[0].text, /analysis complete/);
+  assert.match(reviewResult.content[0].text, /analysis complete/);
+});
+
+test("message and prompt hooks provide intent routing and context injection", async () => {
+  const mock = createMockApi({ baseUrl: "http://paperbot.local" });
+  const mockFetch = async (url) => {
+    if (String(url).endsWith("/api/research/context")) {
+      return new Response(
+        JSON.stringify({
+          memory_items: [{ content: "prefers ICLR papers" }],
+          paper_recommendations: [{ title: "UniICL" }]
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        }
+      );
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  };
+
+  await createPaperBotOpenClawPlugin({ fetchImpl: mockFetch }).register(mock.api);
+  const msgHook = mock.hooks.find((hook) => hook.name === "msg_recv");
+  const promptHook = mock.lifecycleHooks.find((hook) => hook.name === "before_prompt_build");
+
+  const msgPayload = await msgHook.handler({
+    text: "Can you search papers about prompt compression?"
+  });
+  const promptPayload = await promptHook.handler({
+    messages: [{ role: "user", content: "Find papers on prompt compression" }]
+  });
+
+  assert.equal(msgPayload.suggestedTool, "paper_search");
+  assert.match(promptPayload.prependSystemContext, /PaperBot context bridge/);
+  assert.match(promptPayload.prependSystemContext, /paper recommendations: 1/);
+});
+
+test("cron descriptors stay aligned with the planned four OpenClaw jobs", () => {
+  assert.deepEqual(
+    DEFAULT_PAPERBOT_CRON_JOBS.map((job) => job.id),
+    ["paper-monitor", "weekly-digest", "conference-deadlines", "citation-monitor"]
+  );
+});

--- a/openclaw/paperbot-openclaw/tsconfig.json
+++ b/openclaw/paperbot-openclaw/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true,
+    "sourceMap": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- add a standalone paperbot-openclaw TypeScript package under openclaw/
- expose 6 PaperBot bridge tools, message/context hooks, CLI commands, and 4 cron descriptors
- add plugin smoke tests covering registration, HTTP bridge calls, SSE flows, prompt injection, and cron exports

## Validation
- cd openclaw/paperbot-openclaw && npm test

Closes #174