### PR TITLE
fix(obsidian): address sync review feedback

### DIFF
--- a/src/paperbot/api/main.py
+++ b/src/paperbot/api/main.py
@@ -101,6 +101,12 @@ async def _startup_eventlog():
     except Exception:
         # If SQLAlchemy isn't available or DB init fails, fall back to logging only.
         app.state.event_log = LoggingEventLog()
+    obsidian.initialize_obsidian_runtime(app)
+
+
+@app.on_event("shutdown")
+async def _shutdown_obsidian_runtime():
+    obsidian.shutdown_obsidian_runtime(app)
 
 
 if __name__ == "__main__":

--- a/src/paperbot/api/routes/obsidian.py
+++ b/src/paperbot/api/routes/obsidian.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import logging
+import threading
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, List, Optional, TypeVar
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from config.settings import ObsidianConfig, create_settings
@@ -19,29 +21,89 @@ from paperbot.infrastructure.stores.memory_store import SqlAlchemyMemoryStore
 
 router = APIRouter()
 
-_memory_store: Optional[SqlAlchemyMemoryStore] = None
-_vault_watcher: Optional[ObsidianVaultWatcher] = None
+logger = logging.getLogger(__name__)
+
+_MEMORY_STORE_KEY = "obsidian_memory_store"
+_VAULT_WATCHER_KEY = "obsidian_vault_watcher"
+_RUNTIME_LOCK_KEY = "obsidian_runtime_lock"
+_SYNC_LOCK_KEY = "obsidian_sync_lock"
+
+TSyncResult = TypeVar("TSyncResult")
 
 
-def _get_memory_store() -> SqlAlchemyMemoryStore:
-    global _memory_store
-    if _memory_store is None:
-        _memory_store = SqlAlchemyMemoryStore()
-    return _memory_store
+def initialize_obsidian_runtime(app: FastAPI) -> None:
+    if getattr(app.state, _RUNTIME_LOCK_KEY, None) is None:
+        setattr(app.state, _RUNTIME_LOCK_KEY, threading.Lock())
+    if getattr(app.state, _SYNC_LOCK_KEY, None) is None:
+        setattr(app.state, _SYNC_LOCK_KEY, threading.Lock())
+    if not hasattr(app.state, _MEMORY_STORE_KEY):
+        setattr(app.state, _MEMORY_STORE_KEY, None)
+    if not hasattr(app.state, _VAULT_WATCHER_KEY):
+        setattr(app.state, _VAULT_WATCHER_KEY, None)
+
+
+def shutdown_obsidian_runtime(app: FastAPI) -> None:
+    initialize_obsidian_runtime(app)
+
+    watcher = getattr(app.state, _VAULT_WATCHER_KEY, None)
+    stop = getattr(watcher, "stop", None)
+    if callable(stop):
+        stop()
+    setattr(app.state, _VAULT_WATCHER_KEY, None)
+
+    store = getattr(app.state, _MEMORY_STORE_KEY, None)
+    close = getattr(store, "close", None)
+    if callable(close):
+        close()
+    setattr(app.state, _MEMORY_STORE_KEY, None)
+
+
+def _get_runtime_lock(app: FastAPI) -> threading.Lock:
+    initialize_obsidian_runtime(app)
+    return getattr(app.state, _RUNTIME_LOCK_KEY)
+
+
+def _get_sync_lock(app: FastAPI) -> threading.Lock:
+    initialize_obsidian_runtime(app)
+    return getattr(app.state, _SYNC_LOCK_KEY)
+
+
+def _get_memory_store(app: FastAPI) -> SqlAlchemyMemoryStore:
+    initialize_obsidian_runtime(app)
+    store = getattr(app.state, _MEMORY_STORE_KEY, None)
+    if isinstance(store, SqlAlchemyMemoryStore):
+        return store
+
+    with _get_runtime_lock(app):
+        store = getattr(app.state, _MEMORY_STORE_KEY, None)
+        if isinstance(store, SqlAlchemyMemoryStore):
+            return store
+        store = SqlAlchemyMemoryStore()
+        setattr(app.state, _MEMORY_STORE_KEY, store)
+        return store
+
+
+def _get_vault_watcher(app: FastAPI) -> Optional[ObsidianVaultWatcher]:
+    initialize_obsidian_runtime(app)
+    watcher = getattr(app.state, _VAULT_WATCHER_KEY, None)
+    return watcher if isinstance(watcher, ObsidianVaultWatcher) else None
+
+
+def _set_vault_watcher(app: FastAPI, watcher: Optional[ObsidianVaultWatcher]) -> None:
+    initialize_obsidian_runtime(app)
+    setattr(app.state, _VAULT_WATCHER_KEY, watcher)
 
 
 def _get_obsidian_config() -> ObsidianConfig:
     return create_settings().obsidian
 
 
-def _get_event_log(request: Optional[Request]) -> EventLogPort:
-    if request is None:
-        return InMemoryEventLog()
-    event_log = getattr(request.app.state, "event_log", None)
+def _get_event_log(app: FastAPI) -> EventLogPort:
+    event_log = getattr(app.state, "event_log", None)
     return event_log if isinstance(event_log, EventLogPort) else InMemoryEventLog()
 
 
-def _build_obsidian_sync_service(request: Optional[Request] = None) -> ObsidianBidirectionalSync:
+def _build_obsidian_sync_service(app: FastAPI) -> ObsidianBidirectionalSync:
     obsidian_config = _get_obsidian_config()
     vault_value = str(obsidian_config.vault_path or "").strip()
     if not vault_value:
@@ -52,15 +114,34 @@ def _build_obsidian_sync_service(request: Optional[Request] = None) -> ObsidianB
     return ObsidianBidirectionalSync(
         vault_path=Path(vault_value),
         root_dir=str(obsidian_config.root_dir or "PaperBot"),
-        memory_store=_get_memory_store(),
-        event_log=_get_event_log(request),
-        sync_state_filename=getattr(
-            obsidian_config,
-            "sync_state_filename",
-            ".paperbot-sync-state.json",
-        ),
-        pending_dirname=getattr(obsidian_config, "pending_dirname", ".paperbot-pending"),
+        memory_store=_get_memory_store(app),
+        event_log=_get_event_log(app),
+        sync_state_filename=obsidian_config.sync_state_filename,
+        pending_dirname=obsidian_config.pending_dirname,
     )
+
+
+def _run_sync_action(
+    app: FastAPI,
+    action: Callable[[ObsidianBidirectionalSync], TSyncResult],
+) -> TSyncResult:
+    with _get_sync_lock(app):
+        sync_service = _build_obsidian_sync_service(app)
+        return action(sync_service)
+
+
+def _run_scan_task(app: FastAPI) -> None:
+    try:
+        _run_sync_action(app, lambda sync_service: sync_service.scan())
+    except Exception:
+        logger.exception("Obsidian background scan failed")
+
+
+def _run_sync_paths_task(app: FastAPI, paths: List[Path]) -> None:
+    try:
+        _run_sync_action(app, lambda sync_service: sync_service.sync_paths(paths))
+    except Exception:
+        logger.exception("Obsidian watcher sync failed")
 
 
 class ObsidianReportCitationRequest(BaseModel):
@@ -122,16 +203,10 @@ class ObsidianSyncStatusResponse(BaseModel):
 
 
 class ObsidianSyncScanResponse(BaseModel):
-    last_synced_at: str
-    scanned_notes: int
-    changed_notes: int
-    memories_created: int
-    memories_skipped: int
-    tag_updates: int
-    wikilink_updates: int
-    note_updates: int
-    conflicts_detected: int
-    pending_count: int
+    accepted: bool
+    status: str
+    mode: str
+    root_path: str
 
 
 class ObsidianWatchResponse(BaseModel):
@@ -139,6 +214,7 @@ class ObsidianWatchResponse(BaseModel):
     watchdog_available: bool
     mode: str
     root_path: str
+    scan_scheduled: bool = False
 
 
 @router.post("/obsidian/export-report", response_model=ObsidianExportReportResponse)
@@ -158,8 +234,8 @@ def export_obsidian_report(req: ObsidianExportReportRequest) -> ObsidianExportRe
             vault_path=Path(vault_value),
             report=req.model_dump(),
             root_dir=str(req.root_dir or obsidian_config.root_dir or "PaperBot"),
-            track_moc_filename=getattr(obsidian_config, "track_moc_filename", "_MOC.md"),
-            group_tracks_in_folders=getattr(obsidian_config, "group_tracks_in_folders", True),
+            track_moc_filename=obsidian_config.track_moc_filename,
+            group_tracks_in_folders=obsidian_config.group_tracks_in_folders,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -170,67 +246,87 @@ def export_obsidian_report(req: ObsidianExportReportRequest) -> ObsidianExportRe
 @router.get("/obsidian/sync/status", response_model=ObsidianSyncStatusResponse)
 def get_obsidian_sync_status(request: Request) -> ObsidianSyncStatusResponse:
     try:
-        status = _build_obsidian_sync_service(request).get_status().to_dict()
+        status = _run_sync_action(
+            request.app, lambda sync_service: sync_service.get_status()
+        ).to_dict()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     status["watchdog_available"] = WATCHDOG_AVAILABLE
-    status["watching"] = _vault_watcher.is_running if _vault_watcher is not None else False
+    watcher = _get_vault_watcher(request.app)
+    status["watching"] = watcher.is_running if watcher is not None else False
     return ObsidianSyncStatusResponse(**status)
 
 
 @router.post("/obsidian/sync/scan", response_model=ObsidianSyncScanResponse)
-def scan_obsidian_sync(request: Request) -> ObsidianSyncScanResponse:
+def scan_obsidian_sync(
+    request: Request,
+    background_tasks: BackgroundTasks,
+) -> ObsidianSyncScanResponse:
     try:
-        result = _build_obsidian_sync_service(request).scan().to_dict()
+        sync_service = _build_obsidian_sync_service(request.app)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    return ObsidianSyncScanResponse(**result)
+    background_tasks.add_task(_run_scan_task, request.app)
+    return ObsidianSyncScanResponse(
+        accepted=True,
+        status="scan_scheduled",
+        mode="background",
+        root_path=str(sync_service.root_path),
+    )
 
 
 @router.post("/obsidian/sync/watch/start", response_model=ObsidianWatchResponse)
-def start_obsidian_sync_watch(request: Request) -> ObsidianWatchResponse:
-    global _vault_watcher
+def start_obsidian_sync_watch(
+    request: Request,
+    background_tasks: BackgroundTasks,
+) -> ObsidianWatchResponse:
     obsidian_config = _get_obsidian_config()
 
     try:
-        sync_service = _build_obsidian_sync_service(request)
-        sync_service.scan()
+        sync_service = _build_obsidian_sync_service(request.app)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    if _vault_watcher is not None and _vault_watcher.root_path != sync_service.root_path:
-        _vault_watcher.stop()
-        _vault_watcher = None
+    with _get_runtime_lock(request.app):
+        watcher = _get_vault_watcher(request.app)
+        if watcher is not None and watcher.root_path != sync_service.root_path:
+            watcher.stop()
+            _set_vault_watcher(request.app, None)
+            watcher = None
 
-    if _vault_watcher is None:
-        _vault_watcher = ObsidianVaultWatcher(
-            root_path=sync_service.root_path,
-            on_paths_changed=sync_service.sync_paths,
-            debounce_seconds=float(getattr(obsidian_config, "sync_debounce_seconds", 1.0)),
-        )
+        if watcher is None:
+            watcher = ObsidianVaultWatcher(
+                root_path=sync_service.root_path,
+                on_paths_changed=lambda paths: _run_sync_paths_task(request.app, paths),
+                debounce_seconds=obsidian_config.sync_debounce_seconds,
+            )
+            _set_vault_watcher(request.app, watcher)
 
-    watching = _vault_watcher.start()
+        watching = watcher.start()
+    background_tasks.add_task(_run_scan_task, request.app)
     return ObsidianWatchResponse(
         watching=watching,
         watchdog_available=WATCHDOG_AVAILABLE,
         mode="watchdog" if watching else "scan-only",
         root_path=str(sync_service.root_path),
+        scan_scheduled=True,
     )
 
 
 @router.post("/obsidian/sync/watch/stop", response_model=ObsidianWatchResponse)
 def stop_obsidian_sync_watch(request: Request) -> ObsidianWatchResponse:
-    global _vault_watcher
     try:
-        sync_service = _build_obsidian_sync_service(request)
+        sync_service = _build_obsidian_sync_service(request.app)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    if _vault_watcher is not None:
-        _vault_watcher.stop()
-        _vault_watcher = None
+    with _get_runtime_lock(request.app):
+        watcher = _get_vault_watcher(request.app)
+        if watcher is not None:
+            watcher.stop()
+            _set_vault_watcher(request.app, None)
 
     return ObsidianWatchResponse(
         watching=False,

--- a/src/paperbot/infrastructure/exporters/obsidian_exporter.py
+++ b/src/paperbot/infrastructure/exporters/obsidian_exporter.py
@@ -562,6 +562,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         papers_dir: Path,
         paper_refs: List[Dict[str, Any]],
     ) -> None:
+        root_path = papers_dir.parent
         for paper_ref in paper_refs:
             note_path = Path(str(paper_ref.get("path") or "")).expanduser()
             if not note_path:
@@ -576,6 +577,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
                     continue
                 self._update_note_link_index(
                     note_path=target_path,
+                    root_path=root_path,
                     frontmatter_key="cited_by",
                     heading="Cited By",
                     link=current_link,
@@ -587,6 +589,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
                     continue
                 self._update_note_link_index(
                     note_path=target_path,
+                    root_path=root_path,
                     frontmatter_key="cites",
                     heading="References",
                     link=current_link,
@@ -596,6 +599,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         self,
         *,
         note_path: Path,
+        root_path: Path,
         frontmatter_key: str,
         heading: str,
         link: str,
@@ -627,7 +631,7 @@ class ObsidianFilesystemExporter(VaultExporterPort):
         )
         self._write_managed_note(
             note_path=note_path,
-            root_path=note_path.parents[1],
+            root_path=root_path,
             frontmatter_payload=frontmatter,
             managed_body=updated_body,
             managed_headings=PAPER_MANAGED_HEADINGS,

--- a/tests/unit/test_obsidian_exporter.py
+++ b/tests/unit/test_obsidian_exporter.py
@@ -216,6 +216,44 @@ def test_export_library_snapshot_backfills_existing_cited_by_links(tmp_path: Pat
     assert "[[PaperBot/Papers/2026-uniicl-1|UniICL]]" in prior_note
 
 
+def test_update_note_link_index_uses_explicit_root_path(tmp_path: Path, monkeypatch):
+    exporter = ObsidianFilesystemExporter()
+    root_path = tmp_path / "vault" / "PaperBot"
+    note_path = root_path / "Papers" / "nested" / "prior.md"
+    note_path.parent.mkdir(parents=True)
+    note_path.write_text(
+        (
+            "---\n"
+            "paperbot_type: paper\n"
+            "paperbot_managed_links: []\n"
+            "cited_by: []\n"
+            "---\n"
+            "# Prior\n\n"
+            "## Cited By\n"
+            "- [[PaperBot/Papers/existing|Existing]]\n"
+        ),
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _capture_write(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(exporter, "_write_managed_note", _capture_write)
+
+    exporter._update_note_link_index(
+        note_path=note_path,
+        root_path=root_path,
+        frontmatter_key="cited_by",
+        heading="Cited By",
+        link="[[PaperBot/Papers/current|Current]]",
+    )
+
+    assert captured["root_path"] == root_path
+    assert "[[PaperBot/Papers/current|Current]]" in captured["frontmatter_payload"]["cited_by"]
+
+
 def test_export_library_snapshot_requires_existing_vault_directory(tmp_path: Path):
     exporter = ObsidianFilesystemExporter()
     missing_vault = tmp_path / "missing-vault"

--- a/tests/unit/test_obsidian_report_routes.py
+++ b/tests/unit/test_obsidian_report_routes.py
@@ -165,7 +165,7 @@ def test_obsidian_sync_routes_expose_status_scan_and_watch_controls(monkeypatch,
     monkeypatch.setattr(
         obsidian_route,
         "_build_obsidian_sync_service",
-        lambda request=None: fake_sync_service,
+        lambda app: fake_sync_service,
     )
     monkeypatch.setattr(
         obsidian_route,
@@ -174,25 +174,61 @@ def test_obsidian_sync_routes_expose_status_scan_and_watch_controls(monkeypatch,
     )
     monkeypatch.setattr(obsidian_route, "ObsidianVaultWatcher", _FakeWatcher)
     monkeypatch.setattr(obsidian_route, "WATCHDOG_AVAILABLE", True)
-    obsidian_route._vault_watcher = None
 
     with TestClient(app) as client:
+        assert getattr(client.app.state, "obsidian_vault_watcher", None) is None
         status_response = client.get("/api/obsidian/sync/status")
         scan_response = client.post("/api/obsidian/sync/scan")
         start_response = client.post("/api/obsidian/sync/watch/start")
+        assert getattr(client.app.state, "obsidian_vault_watcher", None) is not None
         stop_response = client.post("/api/obsidian/sync/watch/stop")
+        assert getattr(client.app.state, "obsidian_vault_watcher", None) is None
 
     assert status_response.status_code == 200
     assert status_response.json()["tracked_note_count"] == 4
     assert status_response.json()["watchdog_available"] is True
 
     assert scan_response.status_code == 200
-    assert scan_response.json()["memories_created"] == 3
+    assert scan_response.json()["accepted"] is True
+    assert scan_response.json()["status"] == "scan_scheduled"
+    assert scan_response.json()["mode"] == "background"
+    assert scan_response.json()["root_path"] == str(root_path)
 
     assert start_response.status_code == 200
     assert start_response.json()["watching"] is True
     assert start_response.json()["mode"] == "watchdog"
+    assert start_response.json()["scan_scheduled"] is True
 
     assert stop_response.status_code == 200
     assert stop_response.json()["watching"] is False
     assert fake_sync_service.scan_calls >= 2
+
+
+def test_obsidian_runtime_shutdown_closes_store_and_watcher():
+    class _FakeStore:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    class _FakeShutdownWatcher:
+        def __init__(self) -> None:
+            self.stop_calls = 0
+
+        def stop(self) -> None:
+            self.stop_calls += 1
+
+    fake_store = _FakeStore()
+    fake_watcher = _FakeShutdownWatcher()
+
+    obsidian_route.initialize_obsidian_runtime(app)
+    app.state.obsidian_memory_store = fake_store
+    app.state.obsidian_vault_watcher = fake_watcher
+
+    obsidian_route.shutdown_obsidian_runtime(app)
+
+    assert fake_store.close_calls == 1
+    assert fake_watcher.stop_calls == 1
+    assert app.state.obsidian_memory_store is None
+    assert app.state.obsidian_vault_watcher is None


### PR DESCRIPTION
## Summary
- move Obsidian sync runtime resources off module globals and into FastAPI app.state lifecycle management
- schedule sync scans in FastAPI background tasks and serialize sync operations behind app-level locks
- stop using brittle note_path.parents[1] root inference when updating citation backlink indexes

## Validation
- pytest -q tests/unit/test_obsidian*.py tests/unit/test_settings.py