### PR TITLE
ci: disable native Vercel git deploys

### DIFF
--- a/.github/workflows/vercel-auto-deploy.yml
+++ b/.github/workflows/vercel-auto-deploy.yml
@@ -206,40 +206,15 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
-      - name: Comment skip reason on fork PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const marker = "<!-- vercel-preview-fork-notice -->";
-            const body = [
-              marker,
-              "Preview deployment was skipped because this PR comes from a fork and GitHub Actions does not expose the Vercel secrets required for preview deploy and protected preview smoke tests.",
-            ].join("\n");
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) =>
-              comment.user?.type === "Bot" && comment.body?.includes(marker)
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }
+      - name: Record skip reason for fork PR
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Fork PR detected; preview deployment is skipped because GitHub Actions does not expose the Vercel secrets required for protected preview deploys." 
+          {
+            echo "### Fork PR preview skipped"
+            echo
+            echo "This pull request comes from a fork, so GitHub Actions cannot access the Vercel secrets required for preview deployment and protected preview smoke tests."
+            echo
+            echo "The workflow is intentionally passing here to avoid a false-red CI result."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## Summary
- disable Vercel native Git deployments via `vercel.json` so preview deploys only come from GitHub Actions
- change the fork PR notice job to write a job summary instead of commenting on the PR
- keep fork PR CI green when GitHub restricts write permissions on the workflow token

## Why
Fork PRs were failing for two non-code reasons:
- the `Fork PR notice` job tried to create a PR comment with a read-only token on forked pull requests
- Vercel native Git deployments still triggered an authorization gate even though preview deploys are already handled by GitHub Actions

## Validation
- parsed `.github/workflows/vercel-auto-deploy.yml` with `yaml.safe_load`
- parsed `vercel.json` with `JSON.parse`

## Follow-up
- after this lands, branch protection should rely on `Deploy preview` / `Preview smoke` instead of the native `Vercel` status check if that check is currently required