### PR TITLE
fix(web): studio grid and research search polish

### DIFF
--- a/web/src/components/research/SearchBox.tsx
+++ b/web/src/components/research/SearchBox.tsx
@@ -174,7 +174,7 @@ export function SearchBox({
     >
       <div
         className={cn(
-          "relative rounded-2xl border bg-background shadow-md transition-all duration-200",
+          "relative overflow-hidden rounded-2xl border bg-background shadow-md transition-all duration-200",
           "focus-within:shadow-lg focus-within:border-primary/50",
           "hover:shadow-lg",
           disabled && "opacity-60"
@@ -189,7 +189,7 @@ export function SearchBox({
           placeholder={placeholder}
           disabled={disabled || isSearching}
           className={cn(
-            "min-h-[56px] max-h-[200px] resize-none border-0 bg-transparent",
+            "min-h-[56px] max-h-[200px] resize-none border-0 bg-transparent !rounded-none !border-0 !shadow-none",
             "px-5 sm:px-6 pt-4 pb-[56px]",
             "text-base placeholder:text-muted-foreground/50",
             "focus-visible:ring-0 focus-visible:ring-offset-0"

--- a/web/src/components/studio/PaperGallery.tsx
+++ b/web/src/components/studio/PaperGallery.tsx
@@ -430,9 +430,12 @@ export function PaperGallery() {
                         </div>
                     ) : (
                         /* Tiled catalog grid (Image-2 style) */
-                        <div className="grid grid-cols-1 gap-px border border-zinc-300 bg-zinc-300 md:grid-cols-2 xl:grid-cols-4">
+                        <div className="grid grid-cols-1 gap-0 md:grid-cols-2 xl:grid-cols-4">
                             {sortedPapers.map((paper, index) => {
                                 const rowIndex = Math.floor(index / gridColumns)
+                                const colIndex = index % gridColumns
+                                const isFirstRow = rowIndex === 0
+                                const isFirstCol = colIndex === 0
                                 return (
                                     <article
                                         key={paper.id}
@@ -445,7 +448,11 @@ export function PaperGallery() {
                                         }}
                                         role="button"
                                         tabIndex={0}
-                                        className="group relative flex min-h-[300px] cursor-pointer flex-col bg-background p-6 text-left transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2"
+                                        className={cn(
+                                            "group relative flex min-h-[300px] cursor-pointer flex-col border-r border-b border-zinc-300 bg-background p-6 text-left transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 focus-visible:ring-offset-2",
+                                            isFirstRow && "border-t",
+                                            isFirstCol && "border-l",
+                                        )}
                                     >
                                         {/* Delete button */}
                                         <button


### PR DESCRIPTION
## Summary
- remove the overlapping rounded-corner effect in the research search box
- switch the studio paper grid to per-card single-line borders instead of an outer framed gap grid
- intentionally leave  unchanged to avoid carrying unrelated lockfile noise from the old PR

## Why this replaces #374
The old PR is blocked by repository code-scanning rules waiting on historical commits ( / merge commit ) that cannot be retroactively given CodeQL results. This PR rebuilds the same UI changes on top of current  so GitHub can produce a fresh set of CodeQL and CI results.

## Validation
- 
