### PR TITLE
feat(workflow): ground queries with wiki concepts

### DIFF
--- a/src/paperbot/api/main.py
+++ b/src/paperbot/api/main.py
@@ -34,6 +34,7 @@ from .routes import (
     intelligence,
     push_commands,
     agent_board,
+    wiki,
     auth,
 )
 from paperbot.api.error_handling import install_api_error_handling
@@ -93,6 +94,7 @@ app.include_router(feed.router, prefix="/api", tags=["Feed"])
 app.include_router(intelligence.router, prefix="/api", tags=["Intelligence"])
 app.include_router(push_commands.router, prefix="/api", tags=["Push"])
 app.include_router(agent_board.router, tags=["Agent Board"])
+app.include_router(wiki.router, prefix="/api", tags=["Wiki"])
 app.include_router(auth.router)
 
 

--- a/src/paperbot/api/routes/__init__.py
+++ b/src/paperbot/api/routes/__init__.py
@@ -22,6 +22,7 @@ from . import (
     intelligence,
     push_commands,
     agent_board,
+    wiki,
 )
 
 __all__ = [
@@ -46,4 +47,5 @@ __all__ = [
     "intelligence",
     "push_commands",
     "agent_board",
+    "wiki",
 ]

--- a/src/paperbot/api/routes/paperscool.py
+++ b/src/paperbot/api/routes/paperscool.py
@@ -28,6 +28,8 @@ from paperbot.application.services.enrichment_pipeline import (
     LLMEnrichmentStep,
 )
 from paperbot.application.services.paper_search_service import PaperSearchService
+from paperbot.application.services.wiki_concept_service import WikiConceptService
+from paperbot.application.services.workflow_query_grounder import WorkflowQueryGrounder
 from paperbot.application.workflows.analysis.paper_judge import PaperJudge
 from paperbot.application.workflows.dailypaper import (
     DailyPaperReporter,
@@ -44,6 +46,7 @@ from paperbot.infrastructure.services.document_indexing_service import DocumentI
 from paperbot.infrastructure.stores.paper_store import PaperStore
 from paperbot.infrastructure.stores.pipeline_session_store import PipelineSessionStore
 from paperbot.infrastructure.stores.research_store import SqlAlchemyResearchStore
+from paperbot.infrastructure.stores.wiki_concept_store import WikiConceptStore
 from paperbot.infrastructure.stores.workflow_metric_store import WorkflowMetricStore
 from paperbot.utils.text_processing import extract_github_url
 
@@ -51,6 +54,7 @@ router = APIRouter()
 _paper_search_service: Optional[PaperSearchService] = None
 _pipeline_session_store: Optional[PipelineSessionStore] = None
 _workflow_metric_store: Optional[WorkflowMetricStore] = None
+_workflow_query_grounder: Optional[WorkflowQueryGrounder] = None
 
 
 def _get_pipeline_session_store() -> PipelineSessionStore:
@@ -103,6 +107,13 @@ def _get_workflow_metric_store() -> WorkflowMetricStore:
     if _workflow_metric_store is None:
         _workflow_metric_store = WorkflowMetricStore()
     return _workflow_metric_store
+
+
+def _get_workflow_query_grounder() -> WorkflowQueryGrounder:
+    global _workflow_query_grounder
+    if _workflow_query_grounder is None:
+        _workflow_query_grounder = WorkflowQueryGrounder(WikiConceptService(WikiConceptStore()))
+    return _workflow_query_grounder
 
 
 def _count_report_claims_and_evidence(report: Dict[str, Any]) -> tuple[int, int]:
@@ -221,6 +232,7 @@ def _schedule_document_indexing_for_report(
 
 async def _run_topic_search(
     *,
+    user_id: str,
     queries: List[str],
     sources: List[str],
     branches: List[str],
@@ -230,17 +242,20 @@ async def _run_topic_search(
 ) -> Dict[str, Any]:
     return await run_unified_topic_search(
         queries=queries,
+        user_id=user_id,
         sources=sources,
         branches=branches,
         top_k_per_query=top_k_per_query,
         show_per_branch=show_per_branch,
         min_score=min_score,
         search_service=_get_paper_search_service(),
+        query_grounder=_get_workflow_query_grounder(),
         persist=False,
     )
 
 
 class PapersCoolSearchRequest(BaseModel):
+    user_id: str = "default"
     queries: List[str] = Field(default_factory=list)
     sources: List[str] = Field(default_factory=lambda: ["papers_cool"])
     branches: List[str] = Field(default_factory=lambda: ["arxiv", "venue"])
@@ -276,6 +291,7 @@ class PapersCoolCurateResponse(BaseModel):
 
 
 class DailyPaperRequest(BaseModel):
+    user_id: str = "default"
     queries: List[str] = Field(default_factory=list)
     sources: List[str] = Field(default_factory=lambda: ["papers_cool"])
     branches: List[str] = Field(default_factory=lambda: ["arxiv", "venue"])
@@ -376,6 +392,7 @@ async def topic_search(req: PapersCoolSearchRequest):
 
     try:
         result = await _run_topic_search(
+            user_id=req.user_id,
             queries=cleaned_queries,
             sources=req.sources,
             branches=req.branches,
@@ -527,6 +544,7 @@ async def _dailypaper_stream(req: DailyPaperRequest):
             type="progress", data={"phase": "search", "message": "Searching papers..."}
         )
         search_result = await _run_topic_search(
+            user_id=req.user_id,
             queries=cleaned_queries,
             sources=req.sources,
             branches=req.branches,
@@ -932,6 +950,7 @@ async def _sync_daily_report(req: DailyPaperRequest, cleaned_queries: List[str])
     effective_top_k = max(int(req.top_k_per_query), int(req.top_n), 1)
     try:
         search_result = await _run_topic_search(
+            user_id=req.user_id,
             queries=cleaned_queries,
             sources=req.sources,
             branches=req.branches,

--- a/src/paperbot/api/routes/research.py
+++ b/src/paperbot/api/routes/research.py
@@ -12,7 +12,10 @@ from fastapi.responses import Response
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 
-from paperbot.application.services.workflow_query_grounder import WorkflowQueryGrounder
+from paperbot.application.services.workflow_query_grounder import (
+    WorkflowQueryGrounder,
+    build_grounded_routing_query,
+)
 from paperbot.application.services.research_track_context_service import (
     ResearchTrackContextService,
     TrackContextSnapshot,
@@ -2277,9 +2280,13 @@ def suggest_track(req: RouterSuggestRequest):
     grounded_query = _get_workflow_query_grounder().ground_query(
         user_id=req.user_id, query=req.query
     )
+    routing_query = build_grounded_routing_query(
+        original_query=req.query,
+        grounded_query=grounded_query,
+    )
     suggestion = _get_track_router().suggest_track(
         user_id=req.user_id,
-        query=grounded_query.canonical_query or req.query,
+        query=routing_query or req.query,
         active_track_id=int(active["id"]),
     )
     if suggestion is not None and grounded_query.concepts:

--- a/src/paperbot/api/routes/research.py
+++ b/src/paperbot/api/routes/research.py
@@ -12,6 +12,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 
+from paperbot.application.services.workflow_query_grounder import WorkflowQueryGrounder
 from paperbot.application.services.research_track_context_service import (
     ResearchTrackContextService,
     TrackContextSnapshot,
@@ -35,7 +36,9 @@ from paperbot.infrastructure.stores.workflow_metric_store import WorkflowMetricS
 from paperbot.memory.eval.collector import MemoryMetricCollector
 from paperbot.memory.extractor import extract_memories
 from paperbot.memory.schema import MemoryCandidate, NormalizedMessage
+from paperbot.infrastructure.stores.wiki_concept_store import WikiConceptStore
 from paperbot.utils.logging_config import LogFiles, Logger, set_trace_id
+from paperbot.application.services.wiki_concept_service import WikiConceptService
 
 router = APIRouter()
 
@@ -49,6 +52,7 @@ _paper_search_service: Optional["PaperSearchService"] = None
 _document_index_store: Optional["DocumentIndexStore"] = None
 _anchor_service: Optional["AnchorService"] = None
 _subscription_service: Optional["SubscriptionService"] = None
+_workflow_query_grounder: Optional[WorkflowQueryGrounder] = None
 
 
 def _get_research_store() -> SqlAlchemyResearchStore:
@@ -73,6 +77,13 @@ def _get_track_router() -> TrackRouter:
             memory_store=_get_memory_store(),
         )
     return _track_router
+
+
+def _get_workflow_query_grounder() -> WorkflowQueryGrounder:
+    global _workflow_query_grounder
+    if _workflow_query_grounder is None:
+        _workflow_query_grounder = WorkflowQueryGrounder(WikiConceptService(WikiConceptStore()))
+    return _workflow_query_grounder
 
 
 def _build_track_context_service() -> ResearchTrackContextService:
@@ -2263,9 +2274,19 @@ def suggest_track(req: RouterSuggestRequest):
     active = _get_research_store().get_active_track(user_id=req.user_id)
     if not active:
         return RouterSuggestResponse(suggestion=None)
-    suggestion = _get_track_router().suggest_track(
-        user_id=req.user_id, query=req.query, active_track_id=int(active["id"])
+    grounded_query = _get_workflow_query_grounder().ground_query(
+        user_id=req.user_id, query=req.query
     )
+    suggestion = _get_track_router().suggest_track(
+        user_id=req.user_id,
+        query=grounded_query.canonical_query or req.query,
+        active_track_id=int(active["id"]),
+    )
+    if suggestion is not None and grounded_query.concepts:
+        suggestion = {
+            **suggestion,
+            "query_grounding": grounded_query.to_dict(),
+        }
     return RouterSuggestResponse(suggestion=suggestion)
 
 
@@ -2387,6 +2408,7 @@ async def build_context(req: ContextRequest):
         search_service=search_service,
         evidence_retriever=_get_document_index_store(),
         track_router=_get_track_router(),
+        query_grounder=_get_workflow_query_grounder(),
         config=ContextEngineConfig(
             memory_limit=req.memory_limit,
             paper_limit=req.paper_limit,

--- a/src/paperbot/api/routes/wiki.py
+++ b/src/paperbot/api/routes/wiki.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+
+from paperbot.application.services.wiki_concept_service import WikiConceptService
+from paperbot.infrastructure.stores.wiki_concept_store import WikiConceptStore
+
+router = APIRouter()
+
+_service: Optional[WikiConceptService] = None
+
+
+def _get_service() -> WikiConceptService:
+    global _service
+    if _service is None:
+        _service = WikiConceptService(WikiConceptStore())
+    return _service
+
+
+class WikiConceptResponse(BaseModel):
+    id: str
+    name: str
+    description: str
+    definition: str
+    related_papers: List[str]
+    related_concepts: List[str]
+    examples: List[str]
+    category: str
+    icon: str
+    paper_count: int = 0
+    track_count: int = 0
+
+
+class WikiConceptListResponse(BaseModel):
+    items: List[WikiConceptResponse]
+    categories: List[str]
+
+
+@router.get("/wiki/concepts", response_model=WikiConceptListResponse)
+def list_wiki_concepts(
+    user_id: str = Query("default", description="User ID"),
+    q: str = Query("", description="Keyword query"),
+    category: Optional[str] = Query(None, description="Category filter"),
+    limit: int = Query(100, ge=1, le=500),
+):
+    service = _get_service()
+    items = service.list_concepts(user_id=user_id, query=q, category=category, limit=limit)
+    return WikiConceptListResponse(
+        items=[WikiConceptResponse(**item.to_dict()) for item in items],
+        categories=service.categories(),
+    )

--- a/src/paperbot/api/routes/wiki.py
+++ b/src/paperbot/api/routes/wiki.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from paperbot.application.services.wiki_concept_service import WikiConceptService
@@ -11,6 +11,7 @@ from paperbot.infrastructure.stores.wiki_concept_store import WikiConceptStore
 router = APIRouter()
 
 _service: Optional[WikiConceptService] = None
+_DEFAULT_USER_ID = "default"
 
 
 def _get_service() -> WikiConceptService:
@@ -18,6 +19,16 @@ def _get_service() -> WikiConceptService:
     if _service is None:
         _service = WikiConceptService(WikiConceptStore())
     return _service
+
+
+def _resolve_wiki_user_id(requested_user_id: Optional[str]) -> str:
+    user_id = str(requested_user_id or _DEFAULT_USER_ID).strip() or _DEFAULT_USER_ID
+    if user_id != _DEFAULT_USER_ID:
+        raise HTTPException(
+            status_code=403,
+            detail="cross-user wiki grounding requires authenticated user context",
+        )
+    return _DEFAULT_USER_ID
 
 
 class WikiConceptResponse(BaseModel):
@@ -46,8 +57,14 @@ def list_wiki_concepts(
     category: Optional[str] = Query(None, description="Category filter"),
     limit: int = Query(100, ge=1, le=500),
 ):
+    resolved_user_id = _resolve_wiki_user_id(user_id)
     service = _get_service()
-    items = service.list_concepts(user_id=user_id, query=q, category=category, limit=limit)
+    items = service.list_concepts(
+        user_id=resolved_user_id,
+        query=q,
+        category=category,
+        limit=limit,
+    )
     return WikiConceptListResponse(
         items=[WikiConceptResponse(**item.to_dict()) for item in items],
         categories=service.categories(),

--- a/src/paperbot/application/ports/wiki_concept_port.py
+++ b/src/paperbot/application/ports/wiki_concept_port.py
@@ -1,0 +1,39 @@
+"""Port for building a grounded wiki concept snapshot from stored research data."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Protocol, TypedDict, runtime_checkable
+
+
+class PaperGroundingRecord(TypedDict):
+    title: str
+    abstract: str
+    keywords: List[str]
+    fields_of_study: List[str]
+    citation_count: int
+    year: Optional[int]
+
+
+class TrackGroundingRecord(TypedDict):
+    name: str
+    description: str
+    keywords: List[str]
+    methods: List[str]
+
+
+class GroundingSnapshot(TypedDict):
+    papers: List[PaperGroundingRecord]
+    tracks: List[TrackGroundingRecord]
+
+
+@runtime_checkable
+class WikiConceptPort(Protocol):
+    """Read-only interface for wiki grounding inputs."""
+
+    def load_grounding_snapshot(
+        self,
+        *,
+        user_id: str,
+        paper_limit: int = 250,
+        track_limit: int = 100,
+    ) -> GroundingSnapshot: ...

--- a/src/paperbot/application/services/wiki_concept_service.py
+++ b/src/paperbot/application/services/wiki_concept_service.py
@@ -25,12 +25,19 @@ class WikiConceptSeed:
     related_concepts: Tuple[str, ...]
     examples: Tuple[str, ...]
     aliases: Tuple[str, ...] = ()
+    canonical_query: Optional[str] = None
 
     @property
     def terms(self) -> Tuple[str, ...]:
         values = {self.name.lower(), self.id.lower()}
         values.update(alias.lower() for alias in self.aliases if alias.strip())
         return tuple(sorted(values))
+
+    @property
+    def resolved_query(self) -> str:
+        if self.canonical_query:
+            return _normalize_text(self.canonical_query)
+        return _normalize_text(self.name.replace("-", " "))
 
 
 @dataclass(frozen=True)
@@ -44,6 +51,20 @@ class WikiConceptView:
     examples: List[str]
     category: str
     icon: str
+    paper_count: int
+    track_count: int
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ResolvedWikiConcept:
+    id: str
+    name: str
+    category: str
+    canonical_query: str
+    matched_terms: List[str]
     paper_count: int
     track_count: int
 
@@ -66,6 +87,7 @@ _CATALOG: Tuple[WikiConceptSeed, ...] = (
         related_concepts=("Self-Attention", "Positional Encoding", "Multi-Head Attention"),
         examples=("GPT-4", "Claude", "LLaMA"),
         aliases=("transformer", "self-attention", "attention"),
+        canonical_query="transformer",
     ),
     WikiConceptSeed(
         id="rlhf",
@@ -80,6 +102,7 @@ _CATALOG: Tuple[WikiConceptSeed, ...] = (
         related_concepts=("Alignment", "Reward Model", "PPO"),
         examples=("ChatGPT alignment", "Claude training"),
         aliases=("rlhf", "reinforcement learning from human feedback", "alignment"),
+        canonical_query="reinforcement learning from human feedback",
     ),
     WikiConceptSeed(
         id="rag",
@@ -94,6 +117,7 @@ _CATALOG: Tuple[WikiConceptSeed, ...] = (
         related_concepts=("Dense Retrieval", "Context Window", "Vector Index"),
         examples=("Paper QA", "Enterprise search copilots"),
         aliases=("rag", "retrieval-augmented generation", "retrieval augmented generation"),
+        canonical_query="retrieval augmented generation",
     ),
     WikiConceptSeed(
         id="bleu",
@@ -108,6 +132,7 @@ _CATALOG: Tuple[WikiConceptSeed, ...] = (
         related_concepts=("ROUGE", "METEOR", "BERTScore"),
         examples=("MT evaluation", "Summarization scoring"),
         aliases=("bleu", "bleu score"),
+        canonical_query="bleu score",
     ),
     WikiConceptSeed(
         id="diffusion",
@@ -122,6 +147,7 @@ _CATALOG: Tuple[WikiConceptSeed, ...] = (
         related_concepts=("Denoising", "Score Matching", "Latent Diffusion"),
         examples=("Stable Diffusion", "Imagen"),
         aliases=("diffusion", "diffusion model", "latent diffusion"),
+        canonical_query="diffusion models",
     ),
     WikiConceptSeed(
         id="imagenet",
@@ -136,6 +162,7 @@ _CATALOG: Tuple[WikiConceptSeed, ...] = (
         related_concepts=("Transfer Learning", "Pretraining", "Fine-tuning"),
         examples=("ResNet-50 on ImageNet", "ViT benchmarks"),
         aliases=("imagenet",),
+        canonical_query="imagenet",
     ),
 )
 
@@ -231,6 +258,46 @@ class WikiConceptService:
         )
         return filtered[: max(1, limit)]
 
+    def resolve_concepts(
+        self,
+        *,
+        user_id: str,
+        query: str,
+        limit: int = 3,
+    ) -> List[ResolvedWikiConcept]:
+        normalized_query = _normalize_text(query)
+        if not normalized_query:
+            return []
+
+        snapshot = self._concept_store.load_grounding_snapshot(user_id=user_id)
+        matches: List[ResolvedWikiConcept] = []
+        for seed in _CATALOG:
+            matched_terms = self._matched_seed_terms(seed, normalized_query)
+            if not matched_terms:
+                continue
+            view = self._build_view(seed, snapshot)
+            matches.append(
+                ResolvedWikiConcept(
+                    id=seed.id,
+                    name=seed.name,
+                    category=seed.category,
+                    canonical_query=seed.resolved_query,
+                    matched_terms=matched_terms,
+                    paper_count=view.paper_count,
+                    track_count=view.track_count,
+                )
+            )
+
+        matches.sort(
+            key=lambda item: (
+                -self._resolved_query_score(item, normalized_query),
+                -item.paper_count,
+                -item.track_count,
+                item.name.lower(),
+            )
+        )
+        return matches[: max(1, limit)]
+
     @staticmethod
     def categories() -> List[str]:
         categories = sorted({seed.category for seed in _CATALOG})
@@ -269,8 +336,24 @@ class WikiConceptService:
             score += 10
         if _contains_term(_normalize_text(item.category), normalized_query):
             score += 3
-        if any(_contains_term(_normalize_text(paper), normalized_query) for paper in item.related_papers):
+        if any(
+            _contains_term(_normalize_text(paper), normalized_query)
+            for paper in item.related_papers
+        ):
             score += 2
+        return score
+
+    @staticmethod
+    def _matched_seed_terms(seed: WikiConceptSeed, normalized_query: str) -> List[str]:
+        matched = [term for term in seed.terms if _contains_term(normalized_query, term)]
+        return sorted(set(matched), key=lambda term: (-len(term), term))
+
+    @staticmethod
+    def _resolved_query_score(item: ResolvedWikiConcept, normalized_query: str) -> int:
+        score = 0
+        if _contains_term(normalized_query, item.id):
+            score += 20
+        score += sum(max(1, len(term)) for term in item.matched_terms[:3])
         return score
 
     @staticmethod
@@ -283,7 +366,11 @@ class WikiConceptService:
             if any(_contains_term(text, term) for term in seed.terms):
                 matches.append(record)
         matches.sort(
-            key=lambda row: (int(row["citation_count"]), int(row["year"] or 0), row["title"].lower()),
+            key=lambda row: (
+                int(row["citation_count"]),
+                int(row["year"] or 0),
+                row["title"].lower(),
+            ),
             reverse=True,
         )
         return matches

--- a/src/paperbot/application/services/wiki_concept_service.py
+++ b/src/paperbot/application/services/wiki_concept_service.py
@@ -1,0 +1,301 @@
+"""Build a wiki-oriented concept view grounded in stored papers and tracks."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from paperbot.application.ports.wiki_concept_port import (
+    GroundingSnapshot,
+    PaperGroundingRecord,
+    TrackGroundingRecord,
+    WikiConceptPort,
+)
+
+
+@dataclass(frozen=True)
+class WikiConceptSeed:
+    id: str
+    name: str
+    description: str
+    definition: str
+    category: str
+    icon: str
+    related_concepts: Tuple[str, ...]
+    examples: Tuple[str, ...]
+    aliases: Tuple[str, ...] = ()
+
+    @property
+    def terms(self) -> Tuple[str, ...]:
+        values = {self.name.lower(), self.id.lower()}
+        values.update(alias.lower() for alias in self.aliases if alias.strip())
+        return tuple(sorted(values))
+
+
+@dataclass(frozen=True)
+class WikiConceptView:
+    id: str
+    name: str
+    description: str
+    definition: str
+    related_papers: List[str]
+    related_concepts: List[str]
+    examples: List[str]
+    category: str
+    icon: str
+    paper_count: int
+    track_count: int
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+_CATALOG: Tuple[WikiConceptSeed, ...] = (
+    WikiConceptSeed(
+        id="transformer",
+        name="Transformer",
+        description="A deep learning model architecture relying on self-attention mechanisms.",
+        definition=(
+            "The Transformer architecture processes input sequences in parallel using "
+            "self-attention, allowing it to capture long-range dependencies without recurrent "
+            "layers."
+        ),
+        category="Architecture",
+        icon="layers",
+        related_concepts=("Self-Attention", "Positional Encoding", "Multi-Head Attention"),
+        examples=("GPT-4", "Claude", "LLaMA"),
+        aliases=("transformer", "self-attention", "attention"),
+    ),
+    WikiConceptSeed(
+        id="rlhf",
+        name="RLHF",
+        description="Reinforcement Learning from Human Feedback for preference alignment.",
+        definition=(
+            "RLHF trains a reward model on preference data and fine-tunes a base model to "
+            "optimize that reward, improving alignment with human expectations."
+        ),
+        category="Method",
+        icon="target",
+        related_concepts=("Alignment", "Reward Model", "PPO"),
+        examples=("ChatGPT alignment", "Claude training"),
+        aliases=("rlhf", "reinforcement learning from human feedback", "alignment"),
+    ),
+    WikiConceptSeed(
+        id="rag",
+        name="Retrieval-Augmented Generation",
+        description="A retrieval-plus-generation pattern that grounds responses with external context.",
+        definition=(
+            "RAG combines a retriever with a generator so the model can answer using retrieved "
+            "documents, reducing hallucination and improving freshness."
+        ),
+        category="Method",
+        icon="book-open",
+        related_concepts=("Dense Retrieval", "Context Window", "Vector Index"),
+        examples=("Paper QA", "Enterprise search copilots"),
+        aliases=("rag", "retrieval-augmented generation", "retrieval augmented generation"),
+    ),
+    WikiConceptSeed(
+        id="bleu",
+        name="BLEU Score",
+        description="A metric for evaluating overlap between generated and reference text.",
+        definition=(
+            "BLEU compares n-gram overlap between generated output and reference text. It is "
+            "widely used in machine translation and still appears in summarization baselines."
+        ),
+        category="Metric",
+        icon="bar-chart",
+        related_concepts=("ROUGE", "METEOR", "BERTScore"),
+        examples=("MT evaluation", "Summarization scoring"),
+        aliases=("bleu", "bleu score"),
+    ),
+    WikiConceptSeed(
+        id="diffusion",
+        name="Diffusion Models",
+        description="Generative models that learn to reverse a gradual noising process.",
+        definition=(
+            "Diffusion models corrupt data with noise over many steps and learn the reverse "
+            "denoising process to synthesize new samples."
+        ),
+        category="Method",
+        icon="waves",
+        related_concepts=("Denoising", "Score Matching", "Latent Diffusion"),
+        examples=("Stable Diffusion", "Imagen"),
+        aliases=("diffusion", "diffusion model", "latent diffusion"),
+    ),
+    WikiConceptSeed(
+        id="imagenet",
+        name="ImageNet",
+        description="A large-scale visual dataset that became a standard benchmark for vision models.",
+        definition=(
+            "ImageNet contains millions of labeled images and helped define the benchmark culture "
+            "for large-scale visual recognition."
+        ),
+        category="Dataset",
+        icon="image",
+        related_concepts=("Transfer Learning", "Pretraining", "Fine-tuning"),
+        examples=("ResNet-50 on ImageNet", "ViT benchmarks"),
+        aliases=("imagenet",),
+    ),
+)
+
+
+def _normalize_text(value: str) -> str:
+    text = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    return text
+
+
+def _contains_term(text: str, term: str) -> bool:
+    if not text or not term:
+        return False
+    normalized_term = _normalize_text(term)
+    if not normalized_term:
+        return False
+    if " " in normalized_term or "-" in normalized_term:
+        return normalized_term in text
+    if len(normalized_term) <= 4:
+        return re.search(rf"\b{re.escape(normalized_term)}\b", text) is not None
+    return normalized_term in text
+
+
+def _paper_text(record: PaperGroundingRecord) -> str:
+    values: List[str] = [
+        record["title"],
+        record["abstract"],
+        " ".join(record["keywords"]),
+        " ".join(record["fields_of_study"]),
+    ]
+    return _normalize_text(" ".join(values))
+
+
+def _track_text(record: TrackGroundingRecord) -> str:
+    values: List[str] = [
+        record["name"],
+        record["description"],
+        " ".join(record["keywords"]),
+        " ".join(record["methods"]),
+    ]
+    return _normalize_text(" ".join(values))
+
+
+def _concept_query_matches(seed: WikiConceptSeed, item: WikiConceptView, query: str) -> bool:
+    normalized_query = _normalize_text(query)
+    if not normalized_query:
+        return True
+    haystack = _normalize_text(
+        " ".join(
+            [
+                seed.name,
+                seed.description,
+                seed.definition,
+                seed.category,
+                " ".join(seed.terms),
+                " ".join(item.related_papers),
+                " ".join(item.related_concepts),
+                " ".join(item.examples),
+            ]
+        )
+    )
+    return _contains_term(haystack, normalized_query)
+
+
+class WikiConceptService:
+    """Compose curated concept definitions with live paper and track grounding."""
+
+    def __init__(self, concept_store: WikiConceptPort):
+        self._concept_store = concept_store
+
+    def list_concepts(
+        self,
+        *,
+        user_id: str,
+        query: str = "",
+        category: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[WikiConceptView]:
+        snapshot = self._concept_store.load_grounding_snapshot(user_id=user_id)
+        views = [self._build_view(seed, snapshot) for seed in _CATALOG]
+        filtered = [
+            item
+            for seed, item in zip(_CATALOG, views)
+            if self._category_matches(item.category, category)
+            and _concept_query_matches(seed, item, query)
+        ]
+        filtered.sort(
+            key=lambda item: (
+                -self._query_score(item, query),
+                -item.paper_count,
+                -item.track_count,
+                item.name.lower(),
+            ),
+        )
+        return filtered[: max(1, limit)]
+
+    @staticmethod
+    def categories() -> List[str]:
+        categories = sorted({seed.category for seed in _CATALOG})
+        return ["All", *categories]
+
+    def _build_view(self, seed: WikiConceptSeed, snapshot: GroundingSnapshot) -> WikiConceptView:
+        paper_matches = self._matching_papers(seed, snapshot["papers"])
+        track_matches = self._matching_tracks(seed, snapshot["tracks"])
+        return WikiConceptView(
+            id=seed.id,
+            name=seed.name,
+            description=seed.description,
+            definition=seed.definition,
+            related_papers=[paper["title"] for paper in paper_matches[:3]],
+            related_concepts=list(seed.related_concepts),
+            examples=list(seed.examples),
+            category=seed.category,
+            icon=seed.icon,
+            paper_count=len(paper_matches),
+            track_count=len(track_matches),
+        )
+
+    @staticmethod
+    def _category_matches(actual: str, expected: Optional[str]) -> bool:
+        if not expected or expected == "All":
+            return True
+        return actual.lower() == expected.strip().lower()
+
+    @staticmethod
+    def _query_score(item: WikiConceptView, query: str) -> int:
+        normalized_query = _normalize_text(query)
+        if not normalized_query:
+            return 0
+        score = 0
+        if _contains_term(_normalize_text(item.name), normalized_query):
+            score += 10
+        if _contains_term(_normalize_text(item.category), normalized_query):
+            score += 3
+        if any(_contains_term(_normalize_text(paper), normalized_query) for paper in item.related_papers):
+            score += 2
+        return score
+
+    @staticmethod
+    def _matching_papers(
+        seed: WikiConceptSeed, records: Sequence[PaperGroundingRecord]
+    ) -> List[PaperGroundingRecord]:
+        matches: List[PaperGroundingRecord] = []
+        for record in records:
+            text = _paper_text(record)
+            if any(_contains_term(text, term) for term in seed.terms):
+                matches.append(record)
+        matches.sort(
+            key=lambda row: (int(row["citation_count"]), int(row["year"] or 0), row["title"].lower()),
+            reverse=True,
+        )
+        return matches
+
+    @staticmethod
+    def _matching_tracks(
+        seed: WikiConceptSeed, records: Sequence[TrackGroundingRecord]
+    ) -> List[TrackGroundingRecord]:
+        matches: List[TrackGroundingRecord] = []
+        for record in records:
+            text = _track_text(record)
+            if any(_contains_term(text, term) for term in seed.terms):
+                matches.append(record)
+        matches.sort(key=lambda row: row["name"].lower())
+        return matches

--- a/src/paperbot/application/services/workflow_query_grounder.py
+++ b/src/paperbot/application/services/workflow_query_grounder.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Dict, List, Protocol, runtime_checkable
+
+from paperbot.application.services.wiki_concept_service import (
+    ResolvedWikiConcept,
+    WikiConceptService,
+)
+
+
+def _clean_query(query: str) -> str:
+    return re.sub(r"\s+", " ", str(query or "").strip())
+
+
+def _normalize_query(query: str) -> str:
+    return _clean_query(query).lower()
+
+
+def _unique_preserve(values: List[str]) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = []
+    for value in values:
+        cleaned = _clean_query(value)
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(cleaned)
+    return out
+
+
+def _replace_id_term(query: str, *, term: str, replacement: str) -> str:
+    cleaned_query = _clean_query(query)
+    cleaned_term = _clean_query(term)
+    cleaned_replacement = _clean_query(replacement)
+    if not cleaned_query or not cleaned_term or not cleaned_replacement:
+        return cleaned_query
+    pattern = re.compile(rf"\b{re.escape(cleaned_term)}\b", re.IGNORECASE)
+    return pattern.sub(cleaned_replacement, cleaned_query, count=1)
+
+
+@dataclass(frozen=True)
+class GroundedWorkflowConcept:
+    id: str
+    name: str
+    category: str
+    canonical_query: str
+    matched_terms: List[str]
+    paper_count: int
+    track_count: int
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GroundedQuery:
+    original_query: str
+    canonical_query: str
+    search_queries: List[str]
+    concepts: List[GroundedWorkflowConcept]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "original_query": self.original_query,
+            "canonical_query": self.canonical_query,
+            "search_queries": list(self.search_queries),
+            "concepts": [concept.to_dict() for concept in self.concepts],
+        }
+
+
+@runtime_checkable
+class WorkflowQueryGrounderPort(Protocol):
+    def ground_query(self, *, user_id: str, query: str, limit: int = 3) -> GroundedQuery: ...
+
+
+class WorkflowQueryGrounder:
+    """Resolve workflow queries to grounded concepts without over-expanding intent."""
+
+    def __init__(self, concept_service: WikiConceptService):
+        self._concept_service = concept_service
+
+    def ground_query(self, *, user_id: str, query: str, limit: int = 3) -> GroundedQuery:
+        original_query = _clean_query(query)
+        if not original_query:
+            return GroundedQuery(
+                original_query="",
+                canonical_query="",
+                search_queries=[],
+                concepts=[],
+            )
+
+        resolved = self._concept_service.resolve_concepts(
+            user_id=user_id, query=original_query, limit=limit
+        )
+        concepts = [self._to_grounded_concept(item) for item in resolved]
+
+        canonical_query = original_query
+        for concept in resolved:
+            canonical_query = self._apply_concept_resolution(canonical_query, concept)
+
+        search_queries = _unique_preserve([original_query, canonical_query])
+        return GroundedQuery(
+            original_query=original_query,
+            canonical_query=_clean_query(canonical_query),
+            search_queries=search_queries,
+            concepts=concepts,
+        )
+
+    @staticmethod
+    def _to_grounded_concept(item: ResolvedWikiConcept) -> GroundedWorkflowConcept:
+        return GroundedWorkflowConcept(
+            id=item.id,
+            name=item.name,
+            category=item.category,
+            canonical_query=item.canonical_query,
+            matched_terms=list(item.matched_terms),
+            paper_count=item.paper_count,
+            track_count=item.track_count,
+        )
+
+    @staticmethod
+    def _apply_concept_resolution(query: str, concept: ResolvedWikiConcept) -> str:
+        normalized_id = _normalize_query(concept.id)
+        if normalized_id not in {_normalize_query(term) for term in concept.matched_terms}:
+            return query
+        if _normalize_query(concept.canonical_query) == normalized_id:
+            return query
+        return _replace_id_term(query, term=concept.id, replacement=concept.canonical_query)

--- a/src/paperbot/application/services/workflow_query_grounder.py
+++ b/src/paperbot/application/services/workflow_query_grounder.py
@@ -131,3 +131,21 @@ class WorkflowQueryGrounder:
         if _normalize_query(concept.canonical_query) == normalized_id:
             return query
         return _replace_id_term(query, term=concept.id, replacement=concept.canonical_query)
+
+
+def build_grounded_routing_query(
+    *,
+    original_query: str,
+    grounded_query: GroundedQuery | None,
+) -> str:
+    cleaned_original = _clean_query(original_query)
+    if grounded_query is None:
+        return cleaned_original
+    search_queries = getattr(grounded_query, "search_queries", None)
+    canonical_query = getattr(grounded_query, "canonical_query", "")
+    if search_queries is None and hasattr(grounded_query, "to_dict"):
+        payload = grounded_query.to_dict()
+        search_queries = payload.get("search_queries") if isinstance(payload, dict) else None
+        canonical_query = str(payload.get("canonical_query") or canonical_query)
+    values = _unique_preserve([cleaned_original, *list(search_queries or []), canonical_query])
+    return " ".join(values)

--- a/src/paperbot/application/workflows/unified_topic_search.py
+++ b/src/paperbot/application/workflows/unified_topic_search.py
@@ -4,13 +4,19 @@ import asyncio
 import math
 import re
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence
 
 from paperbot.application.services.candidate_search import (
     resolve_candidate_paper_id,
     search_candidate_papers,
 )
 from paperbot.application.services.paper_search_service import PaperSearchService, SearchResult
+
+if TYPE_CHECKING:
+    from paperbot.application.services.workflow_query_grounder import (
+        GroundedQuery,
+        WorkflowQueryGrounderPort,
+    )
 
 
 _QUERY_ALIASES = {
@@ -80,6 +86,16 @@ def _unique_preserve(values: Iterable[str]) -> List[str]:
         seen.add(v)
         out.append(v)
     return out
+
+
+def _default_grounded_query(query: str) -> "GroundedQuery | Dict[str, Any]":
+    cleaned_query = (query or "").strip()
+    return {
+        "original_query": cleaned_query,
+        "canonical_query": cleaned_query,
+        "search_queries": [cleaned_query] if cleaned_query else [],
+        "concepts": [],
+    }
 
 
 def _matched_keywords(paper: Dict[str, Any], tokens: List[str]) -> List[str]:
@@ -154,7 +170,8 @@ def _search_result_to_items(
                 "pdf_url": str(p.get("pdf_url") or "").strip(),
                 "authors": list(p.get("authors") or []),
                 "subject_or_venue": venue,
-                "published_at": p.get("publication_date") or (str(p.get("year")) if p.get("year") else ""),
+                "published_at": p.get("publication_date")
+                or (str(p.get("year")) if p.get("year") else ""),
                 "snippet": str(p.get("abstract") or "").strip(),
                 "keywords": _unique_preserve(
                     [
@@ -184,9 +201,13 @@ def _merge_item(target: Dict[str, Any], incoming: Dict[str, Any]) -> None:
     target["matched_keywords"] = _unique_preserve(
         [*target.get("matched_keywords", []), *incoming.get("matched_keywords", [])]
     )
-    target["branches"] = _unique_preserve([*target.get("branches", []), *incoming.get("branches", [])])
+    target["branches"] = _unique_preserve(
+        [*target.get("branches", []), *incoming.get("branches", [])]
+    )
     target["sources"] = _unique_preserve([*target.get("sources", []), *incoming.get("sources", [])])
-    target["keywords"] = _unique_preserve([*target.get("keywords", []), *incoming.get("keywords", [])])
+    target["keywords"] = _unique_preserve(
+        [*target.get("keywords", []), *incoming.get("keywords", [])]
+    )
     target["authors"] = _unique_preserve([*target.get("authors", []), *incoming.get("authors", [])])
 
     incoming_url = str(incoming.get("url") or "").strip()
@@ -203,12 +224,14 @@ def _merge_item(target: Dict[str, Any], incoming: Dict[str, Any]) -> None:
 async def run_unified_topic_search(
     *,
     queries: Sequence[str],
+    user_id: str = "default",
     branches: Sequence[str] = ("arxiv", "venue"),
     sources: Sequence[str] = ("papers_cool",),
     top_k_per_query: int = 5,
     show_per_branch: int = 25,
     min_score: float = 0.0,
     search_service: Optional[PaperSearchService] = None,
+    query_grounder: Optional["WorkflowQueryGrounderPort"] = None,
     persist: bool = False,
 ) -> Dict[str, Any]:
     normalized_sources = normalize_topic_sources(sources)
@@ -219,14 +242,34 @@ async def run_unified_topic_search(
         raw_query = (raw or "").strip()
         if not raw_query:
             continue
-        normalized_query = _normalize_query(raw_query)
+        grounded = (
+            query_grounder.ground_query(user_id=user_id, query=raw_query)
+            if query_grounder is not None
+            else _default_grounded_query(raw_query)
+        )
+        canonical_query = str(
+            grounded["canonical_query"] if isinstance(grounded, dict) else grounded.canonical_query
+        )
+        search_queries = list(
+            grounded["search_queries"] if isinstance(grounded, dict) else grounded.search_queries
+        )
+        concepts = list(grounded["concepts"] if isinstance(grounded, dict) else grounded.concepts)
+        normalized_query = _normalize_query(canonical_query or raw_query)
         if normalized_query in seen_queries:
             continue
         seen_queries.add(normalized_query)
         query_specs.append(
             {
                 "raw_query": raw_query,
+                "canonical_query": canonical_query or raw_query,
                 "normalized_query": normalized_query,
+                "search_queries": _unique_preserve(
+                    _normalize_query(value) for value in search_queries
+                ),
+                "grounded_concepts": [
+                    concept.to_dict() if hasattr(concept, "to_dict") else dict(concept)
+                    for concept in concepts
+                ],
                 "tokens": _tokenize_query(normalized_query),
             }
         )
@@ -252,12 +295,17 @@ async def run_unified_topic_search(
     max_results = max(1, int(show_per_branch))
 
     tasks = [
-        search_candidate_papers(
-            service,
-            query=spec["normalized_query"],
-            sources=normalized_sources,
-            max_results=max_results,
-            persist=bool(persist),
+        asyncio.gather(
+            *[
+                search_candidate_papers(
+                    service,
+                    query=search_query,
+                    sources=normalized_sources,
+                    max_results=max_results,
+                    persist=bool(persist),
+                )
+                for search_query in (spec["search_queries"] or [spec["normalized_query"]])
+            ]
         )
         for spec in query_specs
     ]
@@ -267,20 +315,44 @@ async def run_unified_topic_search(
     aggregated: List[Dict[str, Any]] = []
     by_key: Dict[str, Dict[str, Any]] = {}
 
-    for spec, search_result in zip(query_specs, search_results):
-        query_items = _search_result_to_items(
-            search_result=search_result,
-            normalized_query=spec["normalized_query"],
-            query_tokens=spec["tokens"],
-            branches=branches,
-            fallback_sources=normalized_sources,
-            min_score=min_score,
-        )
+    for spec, spec_search_results in zip(query_specs, search_results):
+        query_items: List[Dict[str, Any]] = []
+        query_items_by_key: Dict[str, Dict[str, Any]] = {}
+        for search_query, search_result in zip(
+            spec["search_queries"] or [spec["normalized_query"]],
+            spec_search_results,
+        ):
+            current_items = _search_result_to_items(
+                search_result=search_result,
+                normalized_query=search_query,
+                query_tokens=spec["tokens"],
+                branches=branches,
+                fallback_sources=normalized_sources,
+                min_score=min_score,
+            )
+            for item in current_items:
+                url = str(item.get("url") or "").strip().lower()
+                title = str(item.get("title") or "").strip().lower()
+                key = url or title
+                if not key:
+                    continue
+                existing_query_item = query_items_by_key.get(key)
+                if existing_query_item is None:
+                    cloned_query_item = dict(item)
+                    query_items_by_key[key] = cloned_query_item
+                    query_items.append(cloned_query_item)
+                else:
+                    _merge_item(existing_query_item, item)
+
+        query_items.sort(key=lambda row: float(row.get("score") or 0.0), reverse=True)
 
         query_views.append(
             {
                 "raw_query": spec["raw_query"],
+                "canonical_query": spec["canonical_query"],
                 "normalized_query": spec["normalized_query"],
+                "search_queries": spec["search_queries"] or [spec["normalized_query"]],
+                "grounded_concepts": spec["grounded_concepts"],
                 "tokens": spec["tokens"],
                 "total_hits": len(query_items),
                 "items": query_items[: max(0, int(top_k_per_query))],
@@ -312,6 +384,7 @@ async def run_unified_topic_search(
         query_highlights.append(
             {
                 "raw_query": row.get("raw_query") or "",
+                "canonical_query": row.get("canonical_query") or "",
                 "normalized_query": row.get("normalized_query") or "",
                 "hit_count": total_hits,
                 "top_title": (top_item or {}).get("title") or "",

--- a/src/paperbot/context_engine/engine.py
+++ b/src/paperbot/context_engine/engine.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         GroundedQuery,
         WorkflowQueryGrounderPort,
     )
+from paperbot.application.services.workflow_query_grounder import build_grounded_routing_query
 
 # Optional: PaperSearchService for unified search
 try:
@@ -806,10 +807,18 @@ class ContextEngine:
     ) -> Dict[str, Any]:
         grounded_query: Optional["GroundedQuery"] = None
         resolved_query = query
+        routing_query = query
         if self.query_grounder is not None:
             grounded_query = self.query_grounder.ground_query(user_id=user_id, query=query)
             if grounded_query.canonical_query:
                 resolved_query = grounded_query.canonical_query
+            routing_query = (
+                build_grounded_routing_query(
+                    original_query=query,
+                    grounded_query=grounded_query,
+                )
+                or query
+            )
 
         active_track = self.research_store.get_active_track(user_id=user_id)
         routed_track = (
@@ -822,7 +831,7 @@ class ContextEngine:
         if track_id is None and active_track is not None:
             routing_suggestion = self.track_router.suggest_track(
                 user_id=user_id,
-                query=resolved_query,
+                query=routing_query,
                 active_track_id=int(active_track["id"]),
                 limit=50,
             )
@@ -1132,6 +1141,7 @@ class ContextEngine:
             "include_cross_track": bool(include_cross_track),
             "query": query,
             "resolved_query": resolved_query,
+            "routing_query": routing_query,
             "merged_query": merged_query,
             "stage": stage,
             "exploration_ratio": float(exploration_ratio),

--- a/src/paperbot/context_engine/engine.py
+++ b/src/paperbot/context_engine/engine.py
@@ -7,13 +7,19 @@ import random
 import re
 import time
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from paperbot.application.ports.document_intelligence_port import EvidenceRetrieverPort
 from paperbot.context_engine.track_router import TrackRouter, TrackRouterConfig
 from paperbot.infrastructure.stores.memory_store import SqlAlchemyMemoryStore
 from paperbot.infrastructure.stores.research_store import SqlAlchemyResearchStore
 from paperbot.utils.logging_config import Logger, LogFiles
+
+if TYPE_CHECKING:
+    from paperbot.application.services.workflow_query_grounder import (
+        GroundedQuery,
+        WorkflowQueryGrounderPort,
+    )
 
 # Optional: PaperSearchService for unified search
 try:
@@ -520,6 +526,7 @@ class ContextEngine:
         search_service: Optional[Any] = None,
         evidence_retriever: Optional[EvidenceRetrieverPort] = None,
         track_router: Optional[TrackRouter] = None,
+        query_grounder: Optional["WorkflowQueryGrounderPort"] = None,
         config: Optional[ContextEngineConfig] = None,
     ):
         self.research_store = research_store or SqlAlchemyResearchStore()
@@ -527,6 +534,7 @@ class ContextEngine:
         self.paper_store = paper_store
         self.search_service = search_service
         self.evidence_retriever = evidence_retriever
+        self.query_grounder = query_grounder
         self.config = config or ContextEngineConfig()
         self.track_router = track_router or TrackRouter(
             research_store=self.research_store,
@@ -796,6 +804,13 @@ class ContextEngine:
         include_cross_track: bool = False,
         paper_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        grounded_query: Optional["GroundedQuery"] = None
+        resolved_query = query
+        if self.query_grounder is not None:
+            grounded_query = self.query_grounder.ground_query(user_id=user_id, query=query)
+            if grounded_query.canonical_query:
+                resolved_query = grounded_query.canonical_query
+
         active_track = self.research_store.get_active_track(user_id=user_id)
         routed_track = (
             self.research_store.get_track(user_id=user_id, track_id=track_id)
@@ -807,7 +822,7 @@ class ContextEngine:
         if track_id is None and active_track is not None:
             routing_suggestion = self.track_router.suggest_track(
                 user_id=user_id,
-                query=query,
+                query=resolved_query,
                 active_track_id=int(active_track["id"]),
                 limit=50,
             )
@@ -837,7 +852,7 @@ class ContextEngine:
         # Layer 3: paper-scoped memories (on-demand)
         paper_memories = self._load_layer3_paper(user_id, paper_id)
 
-        merged_query = _expand_short_query(query)
+        merged_query = _expand_short_query(resolved_query)
         if routed_track:
             merged_query = _merge_query(merged_query, routed_track.get("keywords") or [])
 
@@ -1116,6 +1131,7 @@ class ContextEngine:
             "used_active_track": track_id is None,
             "include_cross_track": bool(include_cross_track),
             "query": query,
+            "resolved_query": resolved_query,
             "merged_query": merged_query,
             "stage": stage,
             "exploration_ratio": float(exploration_ratio),
@@ -1126,6 +1142,8 @@ class ContextEngine:
             "year_from": self.config.year_from,
             "year_to": self.config.year_to,
         }
+        if grounded_query is not None and grounded_query.concepts:
+            routing["query_grounding"] = grounded_query.to_dict()
 
         context_run_id: Optional[int] = None
         try:
@@ -1253,10 +1271,7 @@ class ContextEngine:
                         file=LogFiles.HARVEST,
                     )
 
-        if (
-            self.evidence_retriever is not None
-            and self.evidence_retriever is not self.paper_store
-        ):
+        if self.evidence_retriever is not None and self.evidence_retriever is not self.paper_store:
             close_fn = getattr(self.evidence_retriever, "close", None)
             if callable(close_fn):
                 try:

--- a/src/paperbot/infrastructure/stores/wiki_concept_store.py
+++ b/src/paperbot/infrastructure/stores/wiki_concept_store.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import json
 from typing import List, Optional
-
-from sqlalchemy import desc, or_, select
 
 from paperbot.application.ports.wiki_concept_port import (
     GroundingSnapshot,
@@ -11,18 +8,8 @@ from paperbot.application.ports.wiki_concept_port import (
     TrackGroundingRecord,
     WikiConceptPort,
 )
-from paperbot.infrastructure.stores.models import PaperModel, ResearchTrackModel
-from paperbot.infrastructure.stores.sqlalchemy_db import SessionProvider, get_db_url
-
-
-def _load_list(raw: str) -> List[str]:
-    try:
-        values = json.loads(raw or "[]")
-        if isinstance(values, list):
-            return [str(value).strip() for value in values if str(value).strip()]
-    except Exception:
-        return []
-    return []
+from paperbot.infrastructure.stores.research_store import SqlAlchemyResearchStore
+from paperbot.infrastructure.stores.sqlalchemy_db import get_db_url
 
 
 class WikiConceptStore(WikiConceptPort):
@@ -30,7 +17,7 @@ class WikiConceptStore(WikiConceptPort):
 
     def __init__(self, db_url: Optional[str] = None):
         self.db_url = db_url or get_db_url()
-        self._provider = SessionProvider(self.db_url)
+        self._research_store = SqlAlchemyResearchStore(db_url=self.db_url)
 
     def load_grounding_snapshot(
         self,
@@ -39,62 +26,44 @@ class WikiConceptStore(WikiConceptPort):
         paper_limit: int = 250,
         track_limit: int = 100,
     ) -> GroundingSnapshot:
-        with self._provider.session() as session:
-            paper_rows = (
-                session.execute(
-                    select(PaperModel)
-                    .where(
-                        PaperModel.deleted_at.is_(None),
-                        or_(
-                            PaperModel.title != "",
-                            PaperModel.abstract != "",
-                        ),
-                    )
-                    .order_by(
-                        desc(PaperModel.citation_count),
-                        desc(PaperModel.updated_at),
-                        desc(PaperModel.created_at),
-                    )
-                    .limit(max(1, paper_limit))
-                )
-                .scalars()
-                .all()
-            )
-            track_rows = (
-                session.execute(
-                    select(ResearchTrackModel)
-                    .where(
-                        ResearchTrackModel.user_id == user_id,
-                        ResearchTrackModel.archived_at.is_(None),
-                    )
-                    .order_by(
-                        desc(ResearchTrackModel.is_active),
-                        desc(ResearchTrackModel.updated_at),
-                    )
-                    .limit(max(1, track_limit))
-                )
-                .scalars()
-                .all()
-            )
-
+        saved_rows = self._research_store.list_saved_papers(
+            user_id=user_id,
+            limit=max(1, paper_limit),
+            sort_by="saved_at",
+        )
+        track_rows = self._research_store.list_tracks(
+            user_id=user_id,
+            include_archived=False,
+            limit=max(1, track_limit),
+        )
         papers: List[PaperGroundingRecord] = [
             {
-                "title": str(row.title or "").strip(),
-                "abstract": str(row.abstract or "").strip(),
-                "keywords": row.get_keywords(),
-                "fields_of_study": row.get_fields_of_study(),
-                "citation_count": int(row.citation_count or 0),
-                "year": int(row.year) if row.year is not None else None,
+                "title": str((row.get("paper") or {}).get("title") or "").strip(),
+                "abstract": str((row.get("paper") or {}).get("abstract") or "").strip(),
+                "keywords": list((row.get("paper") or {}).get("keywords") or []),
+                "fields_of_study": list((row.get("paper") or {}).get("fields_of_study") or []),
+                "citation_count": int((row.get("paper") or {}).get("citation_count") or 0),
+                "year": (
+                    int((row.get("paper") or {}).get("year"))
+                    if (row.get("paper") or {}).get("year") is not None
+                    else None
+                ),
             }
-            for row in paper_rows
+            for row in saved_rows
+            if isinstance(row, dict) and isinstance(row.get("paper"), dict)
         ]
         tracks: List[TrackGroundingRecord] = [
             {
-                "name": str(row.name or "").strip(),
-                "description": str(row.description or "").strip(),
-                "keywords": _load_list(row.keywords_json),
-                "methods": _load_list(row.methods_json),
+                "name": str(row.get("name") or "").strip(),
+                "description": str(row.get("description") or "").strip(),
+                "keywords": [
+                    str(value).strip() for value in row.get("keywords") or [] if str(value).strip()
+                ],
+                "methods": [
+                    str(value).strip() for value in row.get("methods") or [] if str(value).strip()
+                ],
             }
             for row in track_rows
+            if isinstance(row, dict)
         ]
         return {"papers": papers, "tracks": tracks}

--- a/src/paperbot/infrastructure/stores/wiki_concept_store.py
+++ b/src/paperbot/infrastructure/stores/wiki_concept_store.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from typing import List, Optional
+
+from sqlalchemy import desc, or_, select
+
+from paperbot.application.ports.wiki_concept_port import (
+    GroundingSnapshot,
+    PaperGroundingRecord,
+    TrackGroundingRecord,
+    WikiConceptPort,
+)
+from paperbot.infrastructure.stores.models import PaperModel, ResearchTrackModel
+from paperbot.infrastructure.stores.sqlalchemy_db import SessionProvider, get_db_url
+
+
+def _load_list(raw: str) -> List[str]:
+    try:
+        values = json.loads(raw or "[]")
+        if isinstance(values, list):
+            return [str(value).strip() for value in values if str(value).strip()]
+    except Exception:
+        return []
+    return []
+
+
+class WikiConceptStore(WikiConceptPort):
+    """Read model for grounding wiki concepts from stored papers and tracks."""
+
+    def __init__(self, db_url: Optional[str] = None):
+        self.db_url = db_url or get_db_url()
+        self._provider = SessionProvider(self.db_url)
+
+    def load_grounding_snapshot(
+        self,
+        *,
+        user_id: str,
+        paper_limit: int = 250,
+        track_limit: int = 100,
+    ) -> GroundingSnapshot:
+        with self._provider.session() as session:
+            paper_rows = (
+                session.execute(
+                    select(PaperModel)
+                    .where(
+                        PaperModel.deleted_at.is_(None),
+                        or_(
+                            PaperModel.title != "",
+                            PaperModel.abstract != "",
+                        ),
+                    )
+                    .order_by(
+                        desc(PaperModel.citation_count),
+                        desc(PaperModel.updated_at),
+                        desc(PaperModel.created_at),
+                    )
+                    .limit(max(1, paper_limit))
+                )
+                .scalars()
+                .all()
+            )
+            track_rows = (
+                session.execute(
+                    select(ResearchTrackModel)
+                    .where(
+                        ResearchTrackModel.user_id == user_id,
+                        ResearchTrackModel.archived_at.is_(None),
+                    )
+                    .order_by(
+                        desc(ResearchTrackModel.is_active),
+                        desc(ResearchTrackModel.updated_at),
+                    )
+                    .limit(max(1, track_limit))
+                )
+                .scalars()
+                .all()
+            )
+
+        papers: List[PaperGroundingRecord] = [
+            {
+                "title": str(row.title or "").strip(),
+                "abstract": str(row.abstract or "").strip(),
+                "keywords": row.get_keywords(),
+                "fields_of_study": row.get_fields_of_study(),
+                "citation_count": int(row.citation_count or 0),
+                "year": int(row.year) if row.year is not None else None,
+            }
+            for row in paper_rows
+        ]
+        tracks: List[TrackGroundingRecord] = [
+            {
+                "name": str(row.name or "").strip(),
+                "description": str(row.description or "").strip(),
+                "keywords": _load_list(row.keywords_json),
+                "methods": _load_list(row.methods_json),
+            }
+            for row in track_rows
+        ]
+        return {"papers": papers, "tracks": tracks}

--- a/tests/unit/test_context_layers.py
+++ b/tests/unit/test_context_layers.py
@@ -280,6 +280,7 @@ class TestBuildContextPackLayers:
                 config=ContextEngineConfig(offline=False, paper_limit=1),
             )
             engine.search_service = MagicMock()
+            rs.get_active_track.return_value = {"id": 7, "name": "RAG Systems"}
 
             result = await engine.build_context_pack(
                 user_id="u1",
@@ -290,7 +291,13 @@ class TestBuildContextPackLayers:
 
         assert captured_queries == ["retrieval augmented generation latency"]
         assert result["routing"]["resolved_query"] == "retrieval augmented generation latency"
+        assert result["routing"]["routing_query"] == (
+            "rag latency retrieval augmented generation latency"
+        )
         assert result["routing"]["query_grounding"]["concepts"] == [{"id": "rag"}]
+        assert engine.track_router.suggest_track.call_args.kwargs["query"] == (
+            "rag latency retrieval augmented generation latency"
+        )
 
     @pytest.mark.asyncio
     async def test_no_paper_id_layer3_is_zero(self):

--- a/tests/unit/test_context_layers.py
+++ b/tests/unit/test_context_layers.py
@@ -14,7 +14,14 @@ from paperbot.infrastructure.stores.memory_store import SqlAlchemyMemoryStore
 from paperbot.memory.schema import MemoryCandidate
 
 
-def _make_engine(*, memory_store=None, research_store=None, config=None, evidence_retriever=None):
+def _make_engine(
+    *,
+    memory_store=None,
+    research_store=None,
+    config=None,
+    evidence_retriever=None,
+    query_grounder=None,
+):
     """Create a ContextEngine with faked stores."""
     rs = research_store or MagicMock()
     ms = memory_store or MagicMock()
@@ -53,6 +60,7 @@ def _make_engine(*, memory_store=None, research_store=None, config=None, evidenc
         memory_store=ms,
         evidence_retriever=evidence_retriever,
         config=config,
+        query_grounder=query_grounder,
         track_router=MagicMock(),
     )
     return engine, rs, ms
@@ -212,6 +220,77 @@ class TestBuildContextPackLayers:
         assert len(result["evidence_hits"]) == 1
         assert result["evidence_hits"][0]["paper_id"] == 1
         assert result["routing"]["evidence_hit_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_context_pack_uses_grounded_query_for_search_and_routing(self):
+        captured_queries: list[str] = []
+
+        class _FakeGrounder:
+            def ground_query(self, *, user_id: str, query: str, limit: int = 3):
+                return type(
+                    "_Grounded",
+                    (),
+                    {
+                        "canonical_query": "retrieval augmented generation latency",
+                        "concepts": [object()],
+                        "to_dict": lambda self: {
+                            "original_query": query,
+                            "canonical_query": "retrieval augmented generation latency",
+                            "search_queries": [
+                                query,
+                                "retrieval augmented generation latency",
+                            ],
+                            "concepts": [{"id": "rag"}],
+                        },
+                    },
+                )()
+
+        async def _fake_search_candidate_papers(service, *, query, **kwargs):
+            captured_queries.append(query)
+            return object()
+
+        def _fake_search_result_to_candidate_dicts(*args, **kwargs):
+            return [
+                {
+                    "paper_id": "1",
+                    "canonical_id": 1,
+                    "title": "RAG Latency Study",
+                    "abstract": (
+                        "Retrieval-augmented generation latency is analyzed with enough detail "
+                        "to pass the academic paper filter."
+                    ),
+                    "year": 2026,
+                    "citation_count": 4,
+                    "url": "https://example.com/rag-latency",
+                }
+            ]
+
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            monkeypatch.setattr(
+                engine_module, "search_candidate_papers", _fake_search_candidate_papers
+            )
+            monkeypatch.setattr(
+                engine_module,
+                "search_result_to_candidate_dicts",
+                _fake_search_result_to_candidate_dicts,
+            )
+            engine, rs, ms = _make_engine(
+                query_grounder=_FakeGrounder(),
+                config=ContextEngineConfig(offline=False, paper_limit=1),
+            )
+            engine.search_service = MagicMock()
+
+            result = await engine.build_context_pack(
+                user_id="u1",
+                query="rag latency",
+            )
+        finally:
+            monkeypatch.undo()
+
+        assert captured_queries == ["retrieval augmented generation latency"]
+        assert result["routing"]["resolved_query"] == "retrieval augmented generation latency"
+        assert result["routing"]["query_grounding"]["concepts"] == [{"id": "rag"}]
 
     @pytest.mark.asyncio
     async def test_no_paper_id_layer3_is_zero(self):

--- a/tests/unit/test_paperscool_route.py
+++ b/tests/unit/test_paperscool_route.py
@@ -78,7 +78,14 @@ class _FakeWorkflow:
 
 
 async def _fake_run_topic_search(
-    *, queries, sources, branches, top_k_per_query, show_per_branch, min_score=0.0
+    *,
+    user_id="default",
+    queries,
+    sources,
+    branches,
+    top_k_per_query,
+    show_per_branch,
+    min_score=0.0,
 ):
     """Async fake that replaces _run_topic_search for tests."""
     return _FakeWorkflow().run(
@@ -92,7 +99,14 @@ async def _fake_run_topic_search(
 
 
 async def _fake_run_topic_search_multi(
-    *, queries, sources, branches, top_k_per_query, show_per_branch, min_score=0.0
+    *,
+    user_id="default",
+    queries,
+    sources,
+    branches,
+    top_k_per_query,
+    show_per_branch,
+    min_score=0.0,
 ):
     """Async fake returning multiple papers for filter testing."""
     return _FakeWorkflowMultiPaper().run(
@@ -124,6 +138,35 @@ def test_paperscool_search_route_success(monkeypatch):
     payload = resp.json()
     assert payload["source"] == "papers.cool"
     assert payload["summary"]["unique_items"] == 1
+
+
+def test_paperscool_search_route_passes_user_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_search(**kwargs):
+        captured.update(kwargs)
+        return _FakeWorkflow().run(
+            queries=kwargs["queries"],
+            sources=kwargs["sources"],
+            branches=kwargs["branches"],
+            top_k_per_query=kwargs["top_k_per_query"],
+            show_per_branch=kwargs["show_per_branch"],
+            min_score=kwargs["min_score"],
+        )
+
+    monkeypatch.setattr(paperscool_route, "_run_topic_search", _fake_search)
+
+    with TestClient(api_main.app) as client:
+        resp = client.post(
+            "/api/research/paperscool/search",
+            json={
+                "user_id": "u-search",
+                "queries": ["rag latency"],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert captured["user_id"] == "u-search"
 
 
 def test_paperscool_search_route_requires_queries():

--- a/tests/unit/test_research_context_route_explicit_track.py
+++ b/tests/unit/test_research_context_route_explicit_track.py
@@ -64,3 +64,54 @@ def test_context_route_uses_explicit_track_id_without_activation(monkeypatch):
     assert captured["user_id"] == "u-explicit"
     assert response.json()["context_pack"]["routing"]["track_id"] == 42
     assert metric_store.track_ids[-1] == 42
+
+
+def test_router_suggest_uses_grounded_query(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class _FakeResearchStore:
+        def get_active_track(self, *, user_id: str):
+            return {"id": 7, "name": "Retrieval Systems"}
+
+    class _FakeTrackRouter:
+        def suggest_track(self, *, user_id: str, query: str, active_track_id: int):
+            captured["user_id"] = user_id
+            captured["query"] = query
+            captured["active_track_id"] = active_track_id
+            return {"track_id": active_track_id, "score": 0.9}
+
+    class _FakeGrounder:
+        def ground_query(self, *, user_id: str, query: str, limit: int = 3):
+            return type(
+                "_Grounded",
+                (),
+                {
+                    "canonical_query": "retrieval augmented generation latency",
+                    "concepts": [object()],
+                    "to_dict": lambda self: {
+                        "original_query": query,
+                        "canonical_query": "retrieval augmented generation latency",
+                        "search_queries": [
+                            query,
+                            "retrieval augmented generation latency",
+                        ],
+                        "concepts": [{"id": "rag"}],
+                    },
+                },
+            )()
+
+    monkeypatch.setattr(research_route, "_research_store", _FakeResearchStore())
+    monkeypatch.setattr(research_route, "_track_router", _FakeTrackRouter())
+    monkeypatch.setattr(research_route, "_workflow_query_grounder", _FakeGrounder())
+
+    with TestClient(api_main.app) as client:
+        response = client.post(
+            "/api/research/router/suggest",
+            json={"user_id": "u1", "query": "rag latency"},
+        )
+
+    assert response.status_code == 200
+    assert captured["query"] == "retrieval augmented generation latency"
+    assert response.json()["suggestion"]["query_grounding"]["canonical_query"] == (
+        "retrieval augmented generation latency"
+    )

--- a/tests/unit/test_research_context_route_explicit_track.py
+++ b/tests/unit/test_research_context_route_explicit_track.py
@@ -111,7 +111,7 @@ def test_router_suggest_uses_grounded_query(monkeypatch):
         )
 
     assert response.status_code == 200
-    assert captured["query"] == "retrieval augmented generation latency"
+    assert captured["query"] == "rag latency retrieval augmented generation latency"
     assert response.json()["suggestion"]["query_grounding"]["canonical_query"] == (
         "retrieval augmented generation latency"
     )

--- a/tests/unit/test_unified_topic_search_grounding.py
+++ b/tests/unit/test_unified_topic_search_grounding.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+
+from paperbot.application.services.paper_search_service import SearchResult
+from paperbot.application.services.wiki_concept_service import WikiConceptService
+from paperbot.application.services.workflow_query_grounder import WorkflowQueryGrounder
+from paperbot.application.workflows import unified_topic_search as uts
+from paperbot.domain.paper import PaperCandidate
+
+
+class _FakeWikiConceptStore:
+    def load_grounding_snapshot(
+        self,
+        *,
+        user_id: str,
+        paper_limit: int = 250,
+        track_limit: int = 100,
+    ):
+        return {
+            "papers": [
+                {
+                    "title": "Scaling Laws for Retrieval-Augmented Generation",
+                    "abstract": "Retrieval-augmented generation systems scale with corpus quality.",
+                    "keywords": ["rag"],
+                    "fields_of_study": ["Method"],
+                    "citation_count": 24,
+                    "year": 2026,
+                }
+            ],
+            "tracks": [],
+        }
+
+
+@pytest.mark.asyncio
+async def test_run_unified_topic_search_adds_grounded_variants(monkeypatch):
+    captured_queries: list[str] = []
+
+    async def _fake_search_candidate_papers(service, *, query, sources, max_results, persist):
+        captured_queries.append(query)
+        candidate = PaperCandidate(
+            title="Scaling Laws for Retrieval-Augmented Generation",
+            abstract=(
+                "Retrieval-augmented generation systems scale with corpus size and retriever "
+                "quality in enough detail to pass the academic paper filter."
+            ),
+            year=2026,
+            citation_count=24,
+            url="https://example.com/rag-scaling",
+            keywords=["rag", "retrieval"],
+            fields_of_study=["Method"],
+        )
+        return SearchResult(
+            papers=[candidate],
+            provenance={candidate.title_hash: ["papers_cool"]},
+        )
+
+    monkeypatch.setattr(uts, "search_candidate_papers", _fake_search_candidate_papers)
+    grounder = WorkflowQueryGrounder(WikiConceptService(_FakeWikiConceptStore()))
+
+    result = await uts.run_unified_topic_search(
+        user_id="default",
+        queries=["rag latency"],
+        search_service=object(),
+        query_grounder=grounder,
+        persist=False,
+    )
+
+    assert captured_queries == [
+        "rag latency",
+        "retrieval augmented generation latency",
+    ]
+    assert result["queries"][0]["canonical_query"] == "retrieval augmented generation latency"
+    assert result["queries"][0]["search_queries"] == captured_queries
+    assert result["queries"][0]["grounded_concepts"][0]["id"] == "rag"
+    assert result["queries"][0]["items"][0]["matched_queries"] == captured_queries

--- a/tests/unit/test_wiki_concept_service.py
+++ b/tests/unit/test_wiki_concept_service.py
@@ -62,3 +62,15 @@ def test_wiki_concept_service_filters_by_category():
     assert items
     assert all(item.category == "Metric" for item in items)
     assert any(item.id == "bleu" for item in items)
+
+
+def test_wiki_concept_service_resolves_grounded_concepts_for_query():
+    service = WikiConceptService(_FakeWikiConceptStore())
+
+    items = service.resolve_concepts(user_id="default", query="rag latency")
+
+    assert items
+    top = items[0]
+    assert top.id == "rag"
+    assert top.canonical_query == "retrieval augmented generation"
+    assert top.matched_terms == ["rag"]

--- a/tests/unit/test_wiki_concept_service.py
+++ b/tests/unit/test_wiki_concept_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from paperbot.application.ports.wiki_concept_port import GroundingSnapshot
+from paperbot.application.services.wiki_concept_service import WikiConceptService
+
+
+class _FakeWikiConceptStore:
+    def load_grounding_snapshot(
+        self,
+        *,
+        user_id: str,
+        paper_limit: int = 250,
+        track_limit: int = 100,
+    ) -> GroundingSnapshot:
+        return {
+            "papers": [
+                {
+                    "title": "Attention Is All You Need",
+                    "abstract": "The transformer architecture relies on self-attention.",
+                    "keywords": ["transformer", "attention"],
+                    "fields_of_study": ["Architecture"],
+                    "citation_count": 1000,
+                    "year": 2017,
+                },
+                {
+                    "title": "Learning to summarize with BLEU-aware rewards",
+                    "abstract": "We optimize a model with BLEU score as a target metric.",
+                    "keywords": ["bleu", "summarization"],
+                    "fields_of_study": ["Metric"],
+                    "citation_count": 20,
+                    "year": 2024,
+                },
+            ],
+            "tracks": [
+                {
+                    "name": "Alignment Stack",
+                    "description": "Preference optimization and RLHF",
+                    "keywords": ["alignment"],
+                    "methods": ["rlhf"],
+                }
+            ],
+        }
+
+
+def test_wiki_concept_service_enriches_catalog_with_live_grounding():
+    service = WikiConceptService(_FakeWikiConceptStore())
+
+    items = service.list_concepts(user_id="default", query="transformer")
+
+    assert items
+    top = items[0]
+    assert top.id == "transformer"
+    assert top.paper_count == 1
+    assert top.related_papers == ["Attention Is All You Need"]
+
+
+def test_wiki_concept_service_filters_by_category():
+    service = WikiConceptService(_FakeWikiConceptStore())
+
+    items = service.list_concepts(user_id="default", category="Metric")
+
+    assert items
+    assert all(item.category == "Metric" for item in items)
+    assert any(item.id == "bleu" for item in items)

--- a/tests/unit/test_wiki_concept_store.py
+++ b/tests/unit/test_wiki_concept_store.py
@@ -12,7 +12,7 @@ def test_wiki_concept_store_loads_papers_and_tracks(tmp_path: Path):
     paper_store = PaperStore(db_url=db_url)
     research_store = SqlAlchemyResearchStore(db_url=db_url)
 
-    paper_store.upsert_paper(
+    saved_paper = paper_store.upsert_paper(
         paper={
             "title": "Attention Is All You Need",
             "abstract": "Transformer models use self-attention for sequence modeling.",
@@ -22,13 +22,29 @@ def test_wiki_concept_store_loads_papers_and_tracks(tmp_path: Path):
             "year": 2017,
         }
     )
-    research_store.create_track(
+    paper_store.upsert_paper(
+        paper={
+            "title": "Global Unsaved Paper",
+            "abstract": "This row should not appear in user-scoped wiki grounding.",
+            "keywords": ["diffusion"],
+            "fields_of_study": ["Method"],
+            "citation_count": 5,
+            "year": 2026,
+        }
+    )
+    track = research_store.create_track(
         user_id="default",
         name="LLM Agents",
         description="Track the architecture and alignment stack for agents.",
         keywords=["transformer", "agents"],
         methods=["rlhf"],
         activate=True,
+    )
+    research_store.add_paper_feedback(
+        user_id="default",
+        track_id=int(track["id"]),
+        paper_id=str(saved_paper["id"]),
+        action="save",
     )
 
     store = WikiConceptStore(db_url=db_url)

--- a/tests/unit/test_wiki_concept_store.py
+++ b/tests/unit/test_wiki_concept_store.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from paperbot.infrastructure.stores.paper_store import PaperStore
+from paperbot.infrastructure.stores.research_store import SqlAlchemyResearchStore
+from paperbot.infrastructure.stores.wiki_concept_store import WikiConceptStore
+
+
+def test_wiki_concept_store_loads_papers_and_tracks(tmp_path: Path):
+    db_url = f"sqlite:///{tmp_path / 'wiki-grounding.db'}"
+    paper_store = PaperStore(db_url=db_url)
+    research_store = SqlAlchemyResearchStore(db_url=db_url)
+
+    paper_store.upsert_paper(
+        paper={
+            "title": "Attention Is All You Need",
+            "abstract": "Transformer models use self-attention for sequence modeling.",
+            "keywords": ["transformer", "attention"],
+            "fields_of_study": ["Natural Language Processing", "Architecture"],
+            "citation_count": 1000,
+            "year": 2017,
+        }
+    )
+    research_store.create_track(
+        user_id="default",
+        name="LLM Agents",
+        description="Track the architecture and alignment stack for agents.",
+        keywords=["transformer", "agents"],
+        methods=["rlhf"],
+        activate=True,
+    )
+
+    store = WikiConceptStore(db_url=db_url)
+    snapshot = store.load_grounding_snapshot(user_id="default")
+
+    assert len(snapshot["papers"]) == 1
+    assert snapshot["papers"][0]["title"] == "Attention Is All You Need"
+    assert snapshot["papers"][0]["keywords"] == ["transformer", "attention"]
+    assert len(snapshot["tracks"]) == 1
+    assert snapshot["tracks"][0]["name"] == "LLM Agents"
+    assert snapshot["tracks"][0]["methods"] == ["rlhf"]

--- a/tests/unit/test_wiki_route.py
+++ b/tests/unit/test_wiki_route.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from paperbot.api import main as api_main
+from paperbot.api.routes import wiki as wiki_route
+from paperbot.application.services.wiki_concept_service import WikiConceptService
+from paperbot.infrastructure.stores.paper_store import PaperStore
+from paperbot.infrastructure.stores.research_store import SqlAlchemyResearchStore
+from paperbot.infrastructure.stores.wiki_concept_store import WikiConceptStore
+
+
+def test_wiki_route_returns_grounded_concepts(tmp_path: Path, monkeypatch):
+    db_url = f"sqlite:///{tmp_path / 'wiki-route.db'}"
+    paper_store = PaperStore(db_url=db_url)
+    research_store = SqlAlchemyResearchStore(db_url=db_url)
+    paper_store.upsert_paper(
+        paper={
+            "title": "Retrieval-Augmented Generation for Long Context QA",
+            "abstract": "A practical RAG pipeline with retrieval and answer synthesis.",
+            "keywords": ["rag", "retrieval-augmented generation"],
+            "fields_of_study": ["Method"],
+            "citation_count": 42,
+            "year": 2025,
+        }
+    )
+    research_store.create_track(
+        user_id="default",
+        name="RAG Systems",
+        description="Track retrieval-augmented generation and context routing papers.",
+        keywords=["rag"],
+        methods=["retrieval-augmented generation"],
+        activate=True,
+    )
+
+    monkeypatch.setattr(
+        wiki_route,
+        "_service",
+        WikiConceptService(WikiConceptStore(db_url=db_url)),
+    )
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/api/wiki/concepts?q=rag")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "All" in payload["categories"]
+    rag_item = next(item for item in payload["items"] if item["id"] == "rag")
+    assert rag_item["paper_count"] >= 1
+    assert rag_item["track_count"] >= 1
+    assert rag_item["related_papers"] == ["Retrieval-Augmented Generation for Long Context QA"]

--- a/tests/unit/test_wiki_route.py
+++ b/tests/unit/test_wiki_route.py
@@ -16,7 +16,7 @@ def test_wiki_route_returns_grounded_concepts(tmp_path: Path, monkeypatch):
     db_url = f"sqlite:///{tmp_path / 'wiki-route.db'}"
     paper_store = PaperStore(db_url=db_url)
     research_store = SqlAlchemyResearchStore(db_url=db_url)
-    paper_store.upsert_paper(
+    saved_paper = paper_store.upsert_paper(
         paper={
             "title": "Retrieval-Augmented Generation for Long Context QA",
             "abstract": "A practical RAG pipeline with retrieval and answer synthesis.",
@@ -26,13 +26,19 @@ def test_wiki_route_returns_grounded_concepts(tmp_path: Path, monkeypatch):
             "year": 2025,
         }
     )
-    research_store.create_track(
+    track = research_store.create_track(
         user_id="default",
         name="RAG Systems",
         description="Track retrieval-augmented generation and context routing papers.",
         keywords=["rag"],
         methods=["retrieval-augmented generation"],
         activate=True,
+    )
+    research_store.add_paper_feedback(
+        user_id="default",
+        track_id=int(track["id"]),
+        paper_id=str(saved_paper["id"]),
+        action="save",
     )
 
     monkeypatch.setattr(
@@ -51,3 +57,17 @@ def test_wiki_route_returns_grounded_concepts(tmp_path: Path, monkeypatch):
     assert rag_item["paper_count"] >= 1
     assert rag_item["track_count"] >= 1
     assert rag_item["related_papers"] == ["Retrieval-Augmented Generation for Long Context QA"]
+
+
+def test_wiki_route_rejects_cross_user_grounding(monkeypatch):
+    monkeypatch.setattr(
+        wiki_route,
+        "_service",
+        WikiConceptService(WikiConceptStore()),
+    )
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/api/wiki/concepts?user_id=someone-else&q=rag")
+
+    assert response.status_code == 403
+    assert "authenticated user context" in response.json()["detail"]

--- a/tests/unit/test_workflow_query_grounder.py
+++ b/tests/unit/test_workflow_query_grounder.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from paperbot.application.ports.wiki_concept_port import GroundingSnapshot
+from paperbot.application.services.wiki_concept_service import WikiConceptService
+from paperbot.application.services.workflow_query_grounder import WorkflowQueryGrounder
+
+
+class _FakeWikiConceptStore:
+    def load_grounding_snapshot(
+        self,
+        *,
+        user_id: str,
+        paper_limit: int = 250,
+        track_limit: int = 100,
+    ) -> GroundingSnapshot:
+        return {
+            "papers": [
+                {
+                    "title": "Scaling Laws for Retrieval-Augmented Generation",
+                    "abstract": "RAG systems improve retrieval-grounded generation quality.",
+                    "keywords": ["rag", "retrieval"],
+                    "fields_of_study": ["Method"],
+                    "citation_count": 12,
+                    "year": 2026,
+                }
+            ],
+            "tracks": [
+                {
+                    "name": "Retrieval Systems",
+                    "description": "RAG latency and retriever optimization",
+                    "keywords": ["rag"],
+                    "methods": ["retrieval augmented generation"],
+                }
+            ],
+        }
+
+
+def test_workflow_query_grounder_expands_short_concept_ids():
+    grounder = WorkflowQueryGrounder(WikiConceptService(_FakeWikiConceptStore()))
+
+    grounded = grounder.ground_query(user_id="default", query="rag latency")
+
+    assert grounded.original_query == "rag latency"
+    assert grounded.canonical_query == "retrieval augmented generation latency"
+    assert grounded.search_queries == [
+        "rag latency",
+        "retrieval augmented generation latency",
+    ]
+    assert grounded.concepts[0].id == "rag"
+
+
+def test_workflow_query_grounder_keeps_broader_aliases_without_overwriting_query():
+    grounder = WorkflowQueryGrounder(WikiConceptService(_FakeWikiConceptStore()))
+
+    grounded = grounder.ground_query(user_id="default", query="alignment roadmap")
+
+    assert grounded.canonical_query == "alignment roadmap"
+    assert grounded.search_queries == ["alignment roadmap"]

--- a/web/src/app/wiki/page.tsx
+++ b/web/src/app/wiki/page.tsx
@@ -18,49 +18,22 @@ const iconMap: Record<string, LucideIcon> = {
     "bar-chart": BarChart2,
     "waves": Waves,
     "image": ImageIcon,
+    "book-open": BookOpen,
 }
 
 type WikiSearchParams = Promise<{ q?: string | string[] }>
 
-function conceptMatchesKeyword(
-    keyword: string,
-    concept: {
-        name: string
-        description: string
-        definition: string
-        category: string
-        related_papers: string[]
-        related_concepts: string[]
-        examples: string[]
-    },
-) {
-    if (!keyword) return true
-    const haystack = [
-        concept.name,
-        concept.description,
-        concept.definition,
-        concept.category,
-        concept.related_papers.join(" "),
-        concept.related_concepts.join(" "),
-        concept.examples.join(" "),
-    ]
-        .join(" ")
-        .toLowerCase()
-    return haystack.includes(keyword)
-}
-
 export default async function WikiPage({ searchParams }: { searchParams: WikiSearchParams }) {
-    const concepts = await fetchWikiConcepts()
-    const categories = ["All", "Method", "Architecture", "Metric", "Dataset", "Task"]
     const rawKeyword = await searchParams
     const keywordValue = rawKeyword?.q
     const keyword = (Array.isArray(keywordValue) ? keywordValue[0] : keywordValue || "")
         .trim()
         .toLowerCase()
+    const concepts = await fetchWikiConcepts(keyword)
+    const categories = ["All", ...Array.from(new Set(concepts.map((concept) => concept.category)))]
 
     return (
         <div className="flex-1 p-8 pt-6 min-h-screen">
-            {/* Header */}
             <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
                 <div>
                     <h2 className="text-3xl font-bold tracking-tight flex items-center gap-3">
@@ -68,7 +41,7 @@ export default async function WikiPage({ searchParams }: { searchParams: WikiSea
                         Knowledge Base
                     </h2>
                     <p className="text-muted-foreground mt-1">
-                        Explore {concepts.length} core concepts in AI/ML research.
+                        Explore {concepts.length} grounded concepts across your library and active tracks.
                     </p>
                 </div>
                 <form method="get" className="flex w-full md:max-w-md items-center gap-2 bg-background p-1.5 rounded-lg border shadow-sm">
@@ -84,7 +57,6 @@ export default async function WikiPage({ searchParams }: { searchParams: WikiSea
                 </form>
             </div>
 
-            {/* Category Tabs */}
             <Tabs defaultValue="All" className="w-full">
                 <TabsList className="mb-6 bg-muted/50">
                     {categories.map(cat => (
@@ -102,7 +74,7 @@ export default async function WikiPage({ searchParams }: { searchParams: WikiSea
 
                 {categories.map(cat => {
                     const filteredConcepts = concepts.filter(
-                        (c) => (cat === "All" || c.category === cat) && conceptMatchesKeyword(keyword, c),
+                        (c) => cat === "All" || c.category === cat,
                     )
                     return (
                     <TabsContent
@@ -140,7 +112,6 @@ export default async function WikiPage({ searchParams }: { searchParams: WikiSea
 
                                                 <Separator />
 
-                                                {/* Definition */}
                                                 <div>
                                                     <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                                                         <Lightbulb className="h-3 w-3" /> Definition
@@ -148,7 +119,6 @@ export default async function WikiPage({ searchParams }: { searchParams: WikiSea
                                                     <p className="text-sm line-clamp-2">{concept.definition}</p>
                                                 </div>
 
-                                                {/* Related Concepts */}
                                                 <div>
                                                     <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                                                         <Network className="h-3 w-3" /> Related Concepts
@@ -162,7 +132,6 @@ export default async function WikiPage({ searchParams }: { searchParams: WikiSea
                                                     </div>
                                                 </div>
 
-                                                {/* Key Papers */}
                                                 <div>
                                                     <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1">
                                                         <Book className="h-3 w-3" /> Key Papers
@@ -176,14 +145,18 @@ export default async function WikiPage({ searchParams }: { searchParams: WikiSea
                                                     </div>
                                                 </div>
 
-                                                {/* Examples */}
+                                                <p className="text-xs text-muted-foreground">
+                                                    Grounded by {concept.paper_count || 0} papers
+                                                    {" · "}
+                                                    {concept.track_count || 0} track matches
+                                                </p>
+
                                                 {concept.examples.length > 0 && (
                                                     <p className="text-xs text-muted-foreground">
                                                         <span className="font-medium">Examples:</span> {concept.examples.slice(0, 2).join(", ")}
                                                     </p>
                                                 )}
 
-                                                {/* Explore Button */}
                                                 <Button variant="ghost" size="sm" className="w-full mt-1 text-primary hover:bg-primary/5">
                                                     Explore Concept <ArrowRight className="ml-1 h-4 w-4" />
                                                 </Button>

--- a/web/src/app/wiki/page.tsx
+++ b/web/src/app/wiki/page.tsx
@@ -41,7 +41,7 @@ export default async function WikiPage({ searchParams }: { searchParams: WikiSea
                         Knowledge Base
                     </h2>
                     <p className="text-muted-foreground mt-1">
-                        Explore {concepts.length} grounded concepts across your library and active tracks.
+                        Explore {concepts.length} grounded concepts across your saved library and tracks.
                     </p>
                 </div>
                 <form method="get" className="flex w-full md:max-w-md items-center gap-2 bg-background p-1.5 rounded-lg border shadow-sm">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -578,64 +578,23 @@ export async function fetchScholarDetails(id: string): Promise<ScholarDetails> {
     }
 }
 
-export async function fetchWikiConcepts(): Promise<WikiConcept[]> {
-    return [
-        {
-            id: "transformer",
-            name: "Transformer",
-            description: "A deep learning model architecture relying on self-attention mechanisms.",
-            definition: "The Transformer architecture processes input sequences in parallel using self-attention, allowing it to capture long-range dependencies more effectively than RNNs. It consists of encoder and decoder stacks, each containing multi-head attention and feed-forward layers.",
-            related_papers: ["Attention Is All You Need", "BERT", "GPT-3"],
-            related_concepts: ["Self-Attention", "Positional Encoding", "Multi-Head Attention"],
-            examples: ["GPT-4", "Claude", "LLaMA"],
-            category: "Architecture",
-            icon: "layers"
-        },
-        {
-            id: "rlhf",
-            name: "RLHF",
-            description: "Reinforcement Learning from Human Feedback, used to align LLMs with human preferences.",
-            definition: "RLHF trains a reward model on human preference data, then fine-tunes the language model using PPO to maximize the reward. This alignment technique helps reduce harmful outputs and improve helpfulness.",
-            related_papers: ["InstructGPT", "Constitutional AI"],
-            related_concepts: ["PPO", "Reward Model", "Alignment"],
-            examples: ["ChatGPT alignment", "Claude training"],
-            category: "Method",
-            icon: "target"
-        },
-        {
-            id: "bleu",
-            name: "BLEU Score",
-            description: "A metric for evaluating the quality of machine translated text.",
-            definition: "BLEU (Bilingual Evaluation Understudy) compares n-gram overlaps between generated and reference translations. Scores range from 0 to 1, with higher scores indicating better translation quality.",
-            related_papers: ["BLEU: a Method for Automatic Evaluation"],
-            related_concepts: ["ROUGE", "METEOR", "BERTScore"],
-            examples: ["MT evaluation", "Summarization scoring"],
-            category: "Metric",
-            icon: "bar-chart"
-        },
-        {
-            id: "diffusion",
-            name: "Diffusion Models",
-            description: "Generative models that learn to reverse a gradual noising process.",
-            definition: "Diffusion models add Gaussian noise to data over multiple steps, then learn to reverse this process. They achieve state-of-the-art image generation by iteratively denoising random noise into coherent samples.",
-            related_papers: ["DDPM", "Stable Diffusion", "DALL-E 2"],
-            related_concepts: ["Denoising", "Score Matching", "Latent Diffusion"],
-            examples: ["Midjourney", "Stable Diffusion XL"],
-            category: "Method",
-            icon: "waves"
-        },
-        {
-            id: "imagenet",
-            name: "ImageNet",
-            description: "Large-scale visual database for object recognition research.",
-            definition: "ImageNet contains over 14 million images annotated with 20,000+ categories. The ILSVRC subset (1000 classes) became the standard benchmark for image classification, driving major advances in CNNs.",
-            related_papers: ["ImageNet Classification with Deep CNNs"],
-            related_concepts: ["Transfer Learning", "Fine-tuning", "Pretraining"],
-            examples: ["ResNet-50 on ImageNet", "ViT benchmarks"],
-            category: "Dataset",
-            icon: "image"
+export async function fetchWikiConcepts(query?: string): Promise<WikiConcept[]> {
+    const params = new URLSearchParams()
+    if (query && query.trim()) {
+        params.set("q", query.trim())
+    }
+    try {
+        const res = await fetch(`${API_BASE_URL}/wiki/concepts${params.size ? `?${params.toString()}` : ""}`, {
+            cache: "no-store",
+        })
+        if (!res.ok) {
+            return []
         }
-    ]
+        const data = await res.json() as { items?: WikiConcept[] }
+        return data.items || []
+    } catch {
+        return []
+    }
 }
 
 export async function fetchPapers(): Promise<Paper[]> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -107,6 +107,8 @@ export interface WikiConcept {
     examples: string[]
     category: "Method" | "Task" | "Metric" | "Architecture" | "Dataset"
     icon: string // Lucide icon name or identifier
+    paper_count?: number
+    track_count?: number
 }
 
 export interface LLMUsageDailyRecord {


### PR DESCRIPTION
## Summary
- ground wiki concepts from each user's saved library and non-archived tracks instead of the global paper table
- use grounded concepts to expand workflow and research routing queries while preserving original alias terms for track matching
- reject cross-user wiki concept access without authenticated context and align the wiki page copy with saved-library behavior

## Why
- this branch was functionally close, but review surfaced three merge blockers: cross-user wiki data exposure, non-user-scoped grounding inputs, and routing recall loss when acronyms were expanded before track matching
- this follow-up closes those gaps so the feature can merge cleanly into `dev`

## Config / Environment
- no new config or environment variables
- `web` dependencies are not installed in this checkout, so `npm run lint` could not run locally (`eslint: not found`)
- UI change is copy-only on `/wiki`; no layout or interaction changes

## Validation
- `python -m black --check src/paperbot/api/routes/wiki.py src/paperbot/infrastructure/stores/wiki_concept_store.py src/paperbot/application/services/workflow_query_grounder.py src/paperbot/api/routes/research.py src/paperbot/context_engine/engine.py tests/unit/test_wiki_concept_store.py tests/unit/test_wiki_route.py tests/unit/test_research_context_route_explicit_track.py tests/unit/test_context_layers.py`
- `pytest -q tests/unit/test_paperscool_route.py tests/unit/test_research_context_route_explicit_track.py tests/unit/test_context_layers.py tests/unit/test_wiki_concept_service.py tests/unit/test_wiki_concept_store.py tests/unit/test_wiki_route.py tests/unit/test_workflow_query_grounder.py tests/unit/test_unified_topic_search_grounding.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wiki concepts API endpoint for searching research concepts with category filtering, grounded in your saved papers and tracks.
  * Implemented automatic query expansion during search (e.g., "rag" → "retrieval augmented generation latency") to improve result relevance.
  * Extended search and routing workflows to leverage grounded queries throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->