### PR TITLE
feat(paper): switch saved view to dense list

### DIFF
--- a/web/src/components/research/SavedPapersList.test.tsx
+++ b/web/src/components/research/SavedPapersList.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { SavedPaperItem, ReadingStatus } from "./SavedPapersList"
+
+// We import the default component only to ensure the module compiles,
+// but these tests focus on the pure helper logic.
+import SavedPapersList, { formatReadingStatusLabel } from "./SavedPapersList"
+
+describe("formatReadingStatusLabel", () => {
+  it("maps internal reading status values to user-facing labels", () => {
+    const cases: Array<[ReadingStatus, string]> = [
+      ["unread", "To read"],
+      ["reading", "Reading"],
+      ["read", "Read"],
+      ["archived", "Archived"],
+    ]
+
+    for (const [status, expected] of cases) {
+      expect(formatReadingStatusLabel(status)).toBe(expected)
+    }
+  })
+})
+
+describe("SavedPapersList module", () => {
+  it("defines a SavedPaperItem shape compatible with reading status updates", () => {
+    const item: SavedPaperItem = {
+      paper: {
+        id: 1,
+        title: "Test Paper",
+      },
+      saved_at: null,
+      track_id: null,
+      action: "save",
+      reading_status: {
+        status: "unread",
+        updated_at: null,
+      },
+      latest_judge: null,
+    }
+
+    expect(item.paper.id).toBe(1)
+    expect(item.reading_status?.status).toBe("unread")
+  })
+})
+

--- a/web/src/components/research/SavedPapersList.tsx
+++ b/web/src/components/research/SavedPapersList.tsx
@@ -146,6 +146,13 @@ function normalizeStatus(value?: string | null): ReadingStatus {
   return "unread"
 }
 
+function formatReadingStatusLabel(status: ReadingStatus): string {
+  if (status === "reading") return "Reading"
+  if (status === "read") return "Read"
+  if (status === "archived") return "Archived"
+  return "To read"
+}
+
 type SavedPaperListItemProps = {
   item: SavedPaperItem
   status: ReadingStatus
@@ -205,20 +212,6 @@ function SavedPaperListItem({
             </Button>
             <Button
               size="sm"
-              variant="secondary"
-              disabled={rowUpdating}
-              onClick={() => onToggleReadStatus(paper.id, status)}
-            >
-              {togglingRead ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : status === "read" ? (
-                "Reading"
-              ) : (
-                "Mark Read"
-              )}
-            </Button>
-            <Button
-              size="sm"
               variant="ghost"
               disabled={rowUpdating}
               onClick={handleUnsave}
@@ -244,9 +237,55 @@ function SavedPaperListItem({
               Judge {judgeScore}
             </Badge>
           ) : null}
-          <Badge variant="outline" className="text-[11px] md:text-xs">
-            {status}
-          </Badge>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-6 px-2 text-[11px] md:text-xs"
+                disabled={rowUpdating}
+              >
+                {formatReadingStatusLabel(status)}
+                <ChevronDown className="ml-1 h-3 w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-32">
+              <DropdownMenuItem
+                onClick={() => onToggleReadStatus(paper.id, "unread")}
+                className="flex items-center gap-2"
+              >
+                {status === "unread" ? (
+                  <Check className="h-3 w-3" />
+                ) : (
+                  <span className="h-3 w-3" />
+                )}
+                <span>To read</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onToggleReadStatus(paper.id, "reading")}
+                className="flex items-center gap-2"
+              >
+                {status === "reading" ? (
+                  <Check className="h-3 w-3" />
+                ) : (
+                  <span className="h-3 w-3" />
+                )}
+                <span>Reading</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onToggleReadStatus(paper.id, "read")}
+                className="flex items-center gap-2"
+              >
+                {status === "read" ? (
+                  <Check className="h-3 w-3" />
+                ) : (
+                  <span className="h-3 w-3" />
+                )}
+                <span>Read</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         {judgeRecommendation ? (
@@ -441,10 +480,9 @@ export default function SavedPapersList() {
   )
 
   const toggleReadStatus = useCallback(
-    async (paperId: number, currentStatus: ReadingStatus) => {
+    async (paperId: number, nextStatus: ReadingStatus) => {
       setUpdatingAction({ paperId, action: "toggleRead" })
       setError(null)
-      const newStatus = currentStatus === "read" ? "reading" : "read"
       try {
         // Persist reading status so refreshes keep the latest state
         const res = await fetch(`/api/research/papers/${paperId}/status`, {
@@ -452,7 +490,7 @@ export default function SavedPapersList() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             user_id: "default",
-            status: newStatus,
+            status: nextStatus,
           }),
         })
 
@@ -471,7 +509,7 @@ export default function SavedPapersList() {
               ...row,
               reading_status: {
                 ...row.reading_status,
-                status: newStatus,
+                status: nextStatus,
                 updated_at: new Date().toISOString(),
               },
             }

--- a/web/src/components/research/SavedPapersList.tsx
+++ b/web/src/components/research/SavedPapersList.tsx
@@ -24,7 +24,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Textarea } from "@/components/ui/textarea"
 import {
   currentFeedbackFromRequestAction,
@@ -145,6 +144,117 @@ function formatJudge(value?: number | null): string {
 function normalizeStatus(value?: string | null): ReadingStatus {
   if (value === "reading" || value === "read" || value === "archived") return value
   return "unread"
+}
+
+type SavedPaperListItemProps = {
+  item: SavedPaperItem
+  status: ReadingStatus
+  selected: boolean
+  togglingRead: boolean
+  unsaving: boolean
+  onToggleSelect: (paperId: number) => void
+  onToggleReadStatus: (paperId: number, currentStatus: ReadingStatus) => void
+  onUnsave: (paperId: number, externalId: string | null) => void
+}
+
+function SavedPaperListItem({
+  item,
+  status,
+  selected,
+  togglingRead,
+  unsaving,
+  onToggleSelect,
+  onToggleReadStatus,
+  onUnsave,
+}: SavedPaperListItemProps) {
+  const { paper, latest_judge } = item
+  const rowUpdating = togglingRead || unsaving
+  const authorsText = (paper.authors || []).slice(0, 4).join(", ") || "Unknown authors"
+  const source = paper.primary_source || paper.source || "unknown"
+  const savedDate = formatDate(item.saved_at)
+  const publishedDate = formatDate(paper.publication_date || paper.published_at)
+  const judgeScore = formatJudge(latest_judge?.overall)
+  const judgeRecommendation = latest_judge?.recommendation
+
+  const handleUnsave = () => {
+    onUnsave(paper.id, paper.external_url || paper.url || null)
+  }
+
+  return (
+    <div className="flex gap-3 border-b border-border px-3 py-3 last:border-b-0 hover:bg-muted">
+      <div className="pt-1">
+        <Checkbox
+          checked={selected}
+          onCheckedChange={() => onToggleSelect(paper.id)}
+          aria-label={`Select ${paper.title}`}
+        />
+      </div>
+      <div className="flex-1 space-y-1.5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div
+              className="line-clamp-2 text-sm md:text-base font-semibold leading-snug"
+              title={paper.title}
+            >
+              {paper.title}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <Button asChild size="sm" variant="outline">
+              <Link href={`/papers/${paper.id}`}>Detail</Link>
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={rowUpdating}
+              onClick={() => onToggleReadStatus(paper.id, status)}
+            >
+              {togglingRead ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : status === "read" ? (
+                "Reading"
+              ) : (
+                "Mark Read"
+              )}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={rowUpdating}
+              onClick={handleUnsave}
+            >
+              {unsaving ? <Loader2 className="h-3 w-3 animate-spin" /> : "Unsave"}
+            </Button>
+          </div>
+        </div>
+
+        <div className="text-xs text-muted-foreground">{authorsText}</div>
+        {paper.venue ? (
+          <div className="text-xs text-muted-foreground">{paper.venue}</div>
+        ) : null}
+
+        <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] md:text-xs text-muted-foreground">
+          <Badge variant="outline" className="text-[11px] md:text-xs">
+            {source}
+          </Badge>
+          {savedDate !== "-" ? <span>Saved · {savedDate}</span> : null}
+          {publishedDate !== "-" ? <span>Published · {publishedDate}</span> : null}
+          {judgeScore !== "-" ? (
+            <Badge variant="secondary" className="text-[11px] md:text-xs">
+              Judge {judgeScore}
+            </Badge>
+          ) : null}
+          <Badge variant="outline" className="text-[11px] md:text-xs">
+            {status}
+          </Badge>
+        </div>
+
+        {judgeRecommendation ? (
+          <div className="text-[11px] md:text-xs text-muted-foreground">{judgeRecommendation}</div>
+        ) : null}
+      </div>
+    </div>
+  )
 }
 
 export default function SavedPapersList() {
@@ -846,94 +956,43 @@ export default function SavedPapersList() {
           <div className="py-8 text-sm text-muted-foreground">No saved papers yet.</div>
         ) : (
           <>
-            <div className="rounded-md border">
-              <Table className="table-fixed w-full">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-[50px]">
-                      <Checkbox
-                        checked={isAllSelected}
-                        onCheckedChange={toggleSelectAll}
-                        aria-label="Select all"
-                      />
-                    </TableHead>
-                    <TableHead className="w-[40%]">Title</TableHead>
-                    <TableHead className="w-[14%]">Source</TableHead>
-                    <TableHead className="w-[16%] text-center">Saved</TableHead>
-                    <TableHead className="w-[10%] text-center">Judge</TableHead>
-                    <TableHead className="w-[10%] text-center">Status</TableHead>
-                    <TableHead className="w-[10%] text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {pagedItems.map((item) => {
-                    const paper = item.paper
-                    const status = normalizeStatus(item.reading_status?.status)
-                    const togglingRead =
-                      updatingAction?.paperId === paper.id && updatingAction?.action === "toggleRead"
-                    const unsaving =
-                      updatingAction?.paperId === paper.id && updatingAction?.action === "unsave"
-                    const rowUpdating = togglingRead || unsaving
-                    return (
-                      <TableRow key={paper.id}>
-                        <TableCell>
-                          <Checkbox
-                            checked={selectedIds.has(paper.id)}
-                            onCheckedChange={() => toggleSelect(paper.id)}
-                            aria-label={`Select ${paper.title}`}
-                          />
-                        </TableCell>
-                        <TableCell className="max-w-[480px] align-top">
-                          <div className="truncate text-sm font-medium" title={paper.title}>
-                            {paper.title}
-                          </div>
-                          <div className="mt-1 text-xs text-muted-foreground">
-                            {(paper.authors || []).slice(0, 4).join(", ") || "Unknown authors"}
-                          </div>
-                          {paper.venue ? <div className="mt-1 text-xs text-muted-foreground">{paper.venue}</div> : null}
-                        </TableCell>
-                        <TableCell className="whitespace-nowrap">
-                          <Badge variant="outline">{paper.primary_source || paper.source || "unknown"}</Badge>
-                        </TableCell>
-                        <TableCell className="text-center text-xs text-muted-foreground">
-                          <div>{formatDate(item.saved_at)}</div>
-                          <div>Published: {formatDate(paper.publication_date || paper.published_at)}</div>
-                        </TableCell>
-                        <TableCell className="text-center">
-                          <div className="text-sm">{formatJudge(item.latest_judge?.overall)}</div>
-                          {item.latest_judge?.recommendation ? (
-                            <div className="text-xs text-muted-foreground">{item.latest_judge.recommendation}</div>
-                          ) : null}
-                        </TableCell>
-                        <TableCell className="text-center">
-                          <Badge>{status}</Badge>
-                        </TableCell>
-                        <TableCell className="space-x-2 text-right">
-                          <Button asChild size="sm" variant="outline">
-                            <Link href={`/papers/${paper.id}`}>Detail</Link>
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="secondary"
-                            disabled={rowUpdating}
-                            onClick={() => toggleReadStatus(paper.id, status)}
-                          >
-                            {togglingRead ? <Loader2 className="h-3 w-3 animate-spin" /> : status === "read" ? "Reading" : "Mark Read"}
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            disabled={rowUpdating}
-                            onClick={() => unsavePaper(paper.id, paper.external_url || paper.url || null)}
-                          >
-                            {unsaving ? <Loader2 className="h-3 w-3 animate-spin" /> : "Unsave"}
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
-                </TableBody>
-              </Table>
+            <div className="rounded-md border bg-card">
+              <div className="flex items-center justify-between border-b border-border px-3 py-2 text-xs text-muted-foreground">
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    checked={isAllSelected}
+                    onCheckedChange={toggleSelectAll}
+                    aria-label="Select all"
+                  />
+                  <span>Select all</span>
+                </div>
+                <div>
+                  <span>{items.length} papers</span>
+                </div>
+              </div>
+              <div>
+                {pagedItems.map((item) => {
+                  const paper = item.paper
+                  const status = normalizeStatus(item.reading_status?.status)
+                  const togglingRead =
+                    updatingAction?.paperId === paper.id && updatingAction?.action === "toggleRead"
+                  const unsaving =
+                    updatingAction?.paperId === paper.id && updatingAction?.action === "unsave"
+                  return (
+                    <SavedPaperListItem
+                      key={paper.id}
+                      item={item}
+                      status={status}
+                      selected={selectedIds.has(paper.id)}
+                      togglingRead={togglingRead}
+                      unsaving={unsaving}
+                      onToggleSelect={toggleSelect}
+                      onToggleReadStatus={toggleReadStatus}
+                      onUnsave={unsavePaper}
+                    />
+                  )
+                })}
+              </div>
             </div>
             <div className="mt-3 flex items-center justify-between text-sm text-muted-foreground">
               <span>

--- a/web/src/components/research/SavedPapersList.tsx
+++ b/web/src/components/research/SavedPapersList.tsx
@@ -284,6 +284,17 @@ function SavedPaperListItem({
                 )}
                 <span>Read</span>
               </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onToggleReadStatus(paper.id, "archived")}
+                className="flex items-center gap-2"
+              >
+                {status === "archived" ? (
+                  <Check className="h-3 w-3" />
+                ) : (
+                  <span className="h-3 w-3" />
+                )}
+                <span>Archived</span>
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/web/src/components/research/SavedPapersList.tsx
+++ b/web/src/components/research/SavedPapersList.tsx
@@ -34,9 +34,9 @@ import {
 
 type SavedPaperSort = "saved_at" | "judge_score" | "published_at"
 
-type ReadingStatus = "unread" | "reading" | "read" | "archived"
+export type ReadingStatus = "unread" | "reading" | "read" | "archived"
 
-type SavedPaperItem = {
+export type SavedPaperItem = {
   paper: {
     id: number
     title: string
@@ -141,12 +141,12 @@ function formatJudge(value?: number | null): string {
   return `${value.toFixed(2)} / 5.0`
 }
 
-function normalizeStatus(value?: string | null): ReadingStatus {
+export function normalizeStatus(value?: string | null): ReadingStatus {
   if (value === "reading" || value === "read" || value === "archived") return value
   return "unread"
 }
 
-function formatReadingStatusLabel(status: ReadingStatus): string {
+export function formatReadingStatusLabel(status: ReadingStatus): string {
   if (status === "reading") return "Reading"
   if (status === "read") return "Read"
   if (status === "archived") return "Archived"
@@ -160,7 +160,7 @@ type SavedPaperListItemProps = {
   togglingRead: boolean
   unsaving: boolean
   onToggleSelect: (paperId: number) => void
-  onToggleReadStatus: (paperId: number, currentStatus: ReadingStatus) => void
+  onToggleReadStatus: (paperId: number, nextStatus: ReadingStatus) => void
   onUnsave: (paperId: number, externalId: string | null) => void
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned saved papers from table rows to card-like items with per-item actions (Details, Unsave) and status controls for clearer layout and interaction.
  * Improved reading status labels for clearer user-facing text.
  * Updated paging summary to show correct range (Showing x–y of z) with Prev/Next controls.

* **Tests**
  * Added unit tests validating reading status labels and per-item behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->