### PR TITLE
fix(migration): use batch_alter_table for SQLite in 0022

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, event, pool, text
 
 # Alembic Config object
 config = context.config
@@ -41,6 +41,47 @@ def _ensure_sqlite_parent_dir(db_url: str) -> None:
         return
     Path(path).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
 
+
+def _configure_sqlite_extensions(connectable, db_url: str) -> None:
+    if not db_url.startswith("sqlite"):
+        return
+
+    try:
+        import sqlite_vec  # type: ignore
+    except Exception:
+        return
+
+    @event.listens_for(connectable, "connect")
+    def _load_vec(dbapi_conn, _):
+        dbapi_conn.enable_load_extension(True)
+        try:
+            sqlite_vec.load(dbapi_conn)
+        finally:
+            dbapi_conn.enable_load_extension(False)
+
+
+def _validate_sqlite_extensions(connection, db_url: str) -> None:
+    if not db_url.startswith("sqlite"):
+        return
+
+    rows = connection.execute(
+        text(
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE sql IS NOT NULL AND sql LIKE '%vec0(%'"
+        )
+    ).fetchall()
+    if not rows:
+        return
+
+    try:
+        connection.execute(text("SELECT vec_version()"))
+    except Exception as exc:  # pragma: no cover - depends on local sqlite extension state.
+        object_names = ", ".join(row.name for row in rows)
+        raise RuntimeError(
+            "SQLite schema depends on sqlite-vec objects "
+            f"({object_names}), but the Alembic connection could not load sqlite_vec. "
+            "Install sqlite-vec or ensure the extension can be loaded before running migrations."
+        ) from exc
 
 def get_target_metadata():
     # Import here so env.py doesn't import app code unless needed.
@@ -82,8 +123,10 @@ def run_migrations_online() -> None:
         poolclass=pool.NullPool,
         connect_args=connect_args,
     )
+    _configure_sqlite_extensions(connectable, db_url)
 
     with connectable.connect() as connection:
+        _validate_sqlite_extensions(connection, db_url)
         context.configure(
             connection=connection,
             target_metadata=target_metadata,

--- a/alembic/versions/0022_repro_experience_dedup.py
+++ b/alembic/versions/0022_repro_experience_dedup.py
@@ -21,29 +21,105 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade() -> None:
-    # Add user_id column (nullable first, then set default, then NOT NULL)
-    op.add_column(
-        "repro_code_experience",
-        sa.Column("user_id", sa.String(64), nullable=True),
+def _has_column(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(col["name"] == column_name for col in inspector.get_columns(table_name))
+
+
+def _is_column_nullable(table_name: str, column_name: str) -> bool | None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for col in inspector.get_columns(table_name):
+        if col["name"] == column_name:
+            return bool(col.get("nullable", True))
+    return None
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(idx["name"] == index_name for idx in inspector.get_indexes(table_name))
+
+
+def _has_unique_constraint(table_name: str, constraint_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(
+        uq.get("name") == constraint_name
+        for uq in inspector.get_unique_constraints(table_name)
     )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_sqlite = bind.dialect.name == "sqlite"
+
+    # Add user_id column (nullable first, then backfill, then NOT NULL)
+    if not _has_column("repro_code_experience", "user_id"):
+        op.add_column(
+            "repro_code_experience",
+            sa.Column("user_id", sa.String(64), nullable=True),
+        )
+
     op.execute("UPDATE repro_code_experience SET user_id = 'default' WHERE user_id IS NULL")
-    op.alter_column("repro_code_experience", "user_id", nullable=False)
-    op.create_index("ix_repro_code_experience_user_id", "repro_code_experience", ["user_id"])
+
+    if _is_column_nullable("repro_code_experience", "user_id"):
+        if is_sqlite:
+            with op.batch_alter_table("repro_code_experience") as batch_op:
+                batch_op.alter_column(
+                    "user_id",
+                    existing_type=sa.String(length=64),
+                    nullable=False,
+                )
+        else:
+            op.alter_column(
+                "repro_code_experience",
+                "user_id",
+                existing_type=sa.String(length=64),
+                nullable=False,
+            )
+
+    if not _has_index("repro_code_experience", "ix_repro_code_experience_user_id"):
+        op.create_index("ix_repro_code_experience_user_id", "repro_code_experience", ["user_id"])
 
     # Dedup unique constraint (user_id + paper_id + pattern_type + content)
-    op.create_unique_constraint(
-        "uq_repro_exp_user_paper_type_content",
-        "repro_code_experience",
-        ["user_id", "paper_id", "pattern_type", "content"],
-    )
+    if not _has_unique_constraint("repro_code_experience", "uq_repro_exp_user_paper_type_content"):
+        if is_sqlite:
+            with op.batch_alter_table("repro_code_experience") as batch_op:
+                batch_op.create_unique_constraint(
+                    "uq_repro_exp_user_paper_type_content",
+                    ["user_id", "paper_id", "pattern_type", "content"],
+                )
+        else:
+            op.create_unique_constraint(
+                "uq_repro_exp_user_paper_type_content",
+                "repro_code_experience",
+                ["user_id", "paper_id", "pattern_type", "content"],
+            )
 
 
 def downgrade() -> None:
-    op.drop_constraint(
-        "uq_repro_exp_user_paper_type_content",
-        "repro_code_experience",
-        type_="unique",
-    )
-    op.drop_index("ix_repro_code_experience_user_id", table_name="repro_code_experience")
-    op.drop_column("repro_code_experience", "user_id")
+    bind = op.get_bind()
+    is_sqlite = bind.dialect.name == "sqlite"
+
+    if _has_unique_constraint("repro_code_experience", "uq_repro_exp_user_paper_type_content"):
+        if is_sqlite:
+            with op.batch_alter_table("repro_code_experience") as batch_op:
+                batch_op.drop_constraint("uq_repro_exp_user_paper_type_content", type_="unique")
+        else:
+            op.drop_constraint(
+                "uq_repro_exp_user_paper_type_content",
+                "repro_code_experience",
+                type_="unique",
+            )
+
+    if _has_index("repro_code_experience", "ix_repro_code_experience_user_id"):
+        op.drop_index("ix_repro_code_experience_user_id", table_name="repro_code_experience")
+
+    if _has_column("repro_code_experience", "user_id"):
+        if is_sqlite:
+            with op.batch_alter_table("repro_code_experience") as batch_op:
+                batch_op.drop_column("user_id")
+        else:
+            op.drop_column("repro_code_experience", "user_id")

--- a/tests/integration/test_alembic_sqlite_vec_env.py
+++ b/tests/integration/test_alembic_sqlite_vec_env.py
@@ -1,0 +1,73 @@
+﻿from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALEMBIC_INI = REPO_ROOT / "alembic.ini"
+
+
+def test_sqlite_vec_is_loaded_for_followup_migrations(tmp_path):
+    pytest.importorskip("sqlite_vec")
+
+    db_path = tmp_path / "alembic-sqlite-vec.db"
+    db_url = f"sqlite:///{db_path.as_posix()}"
+    env = os.environ.copy()
+    env["PAPERBOT_DB_URL"] = db_url
+
+    def run_upgrade(revision: str) -> subprocess.CompletedProcess[str]:
+        script = (
+            "from alembic import command; "
+            "from alembic.config import Config; "
+            f"cfg = Config(r'{ALEMBIC_INI.as_posix()}'); "
+            f"cfg.set_main_option('script_location', r'{(REPO_ROOT / 'alembic').as_posix()}'); "
+            f"command.upgrade(cfg, '{revision}')"
+        )
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    result_0021 = run_upgrade("0021_repro_code_experience")
+    assert result_0021.returncode == 0, result_0021.stdout + result_0021.stderr
+
+    import sqlite_vec
+
+    with sqlite3.connect(db_path) as conn:
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+        conn.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(embedding float[8])"
+        )
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS memory_items_vec_ai
+            AFTER INSERT ON memory_items
+            WHEN new.embedding IS NOT NULL
+            BEGIN
+                INSERT OR REPLACE INTO vec_items(rowid, embedding) VALUES (new.id, new.embedding);
+            END
+            """
+        )
+        objects = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'trigger')"
+            ).fetchall()
+        }
+
+    assert "vec_items" in objects
+    assert "memory_items_vec_ai" in objects
+
+    result_0022 = run_upgrade("0022_repro_experience_dedup")
+    assert result_0022.returncode == 0, result_0022.stdout + result_0022.stderr


### PR DESCRIPTION
SQLite does not support ALTER COLUMN directly. Wrap ALTER operations in batch_alter_table and add idempotency guards for safe re-runs.
- 背景
在默认 SQLite 环境执行 alembic upgrade head 时，迁移 0022 失败，报错为 near "ALTER": syntax error。
- 根因
迁移脚本在 SQLite 下执行了不兼容的 ALTER COLUMN 语法。
- 修复
在 0022 迁移中对 SQLite 使用 batch_alter_table，并补充对象存在性检查，兼容半执行状态重跑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database migration robustness with idempotent, dialect-aware migration behavior and safer schema changes.
  * Added runtime checks to ensure required SQLite extensions are available during migrations.
* **Tests**
  * Added an integration test that verifies SQLite extension loading and successful follow-up migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->