### PR TITLE
fix(web): migrate middleware to proxy

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,7 +1,7 @@
 import { auth } from "@/auth"
 import { NextResponse } from "next/server"
 
-// Only allow unauthenticated access to explicit auth pages.
+// Proxy only allows unauthenticated access to explicit auth pages.
 // All other paths (including "/") require a valid session.
 const PUBLIC_PATHS = ["/login", "/register", "/forgot-password", "/reset-password"]
 


### PR DESCRIPTION
## What changed
- rename `web/src/middleware.ts` to `web/src/proxy.ts`
- keep the existing auth gating logic and matcher unchanged
- align the app with the Next.js 16 file convention to remove the deprecation warning during build

## Why
Syncing to the latest `dev` already removes the stale `TrackSpotlightSection` type error from the original failure report. The remaining code-level issue on current `dev` was the Next.js 16.1.0 warning that the `middleware` file convention is deprecated in favor of `proxy`.

## Config / environment impact
- no env var changes
- no backend/API contract changes

## Validation
- `cd web && npm ci`
- `cd web && npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified wording in a comment to better describe proxy authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->