### PR TITLE
refactor: normalize repro test imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # tests/conftest.py
 """
 Pytest configuration and fixtures.
-Adds src/paperbot to sys.path so imports work correctly.
+Adds the project `src` directory to `sys.path` so `paperbot` imports resolve in tests.
 """
 
 import sys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,16 +13,11 @@ src_root = project_root / "src"
 if str(src_root) not in sys.path:
     sys.path.insert(0, str(src_root))
 
-# Keep legacy behavior: add src/paperbot so `import repro` style tests keep working
-legacy_src_path = src_root / "paperbot"
-if str(legacy_src_path) not in sys.path:
-    sys.path.insert(0, str(legacy_src_path))
-
 # Also add project root
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-# Exclude legacy test files that use old import paths (agents.xxx, repro.xxx, etc.)
+# Exclude stale root-level tests pending dedicated cleanup PRs.
 collect_ignore = [
     str(Path(__file__).parent / "test_code_analysis_fallback.py"),
     str(Path(__file__).parent / "test_conference_agent_stats.py"),

--- a/tests/integration/test_repro_deepcode.py
+++ b/tests/integration/test_repro_deepcode.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from repro import (
+from paperbot.repro import (
     AgentResult,
     Blueprint,
     CodeKnowledgeBase,

--- a/tests/test_generation_agent.py
+++ b/tests/test_generation_agent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from repro import Blueprint, GenerationNode, ImplementationSpec, ReproductionPlan
+from paperbot.repro import Blueprint, GenerationNode, ImplementationSpec, ReproductionPlan
 
 
 def test_generation_node_fallback_templates_cover_known_and_generic_files():

--- a/tests/test_repro_agent.py
+++ b/tests/test_repro_agent.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from repro import (
+from paperbot.repro import (
     EnvironmentSpec,
     ExecutionResult,
     ImplementationSpec,

--- a/tests/test_repro_e2e.py
+++ b/tests/test_repro_e2e.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from repro import (
+from paperbot.repro import (
     EnvironmentSpec,
     ImplementationSpec,
     NodeResult,

--- a/tests/test_repro_models.py
+++ b/tests/test_repro_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from repro import (
+from paperbot.repro import (
     ImplementationSpec,
     PaperContext,
     ReproductionPlan,

--- a/tests/test_repro_planning.py
+++ b/tests/test_repro_planning.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from repro import Blueprint, PaperContext, PlanningNode, ReproductionPlan
+from paperbot.repro import Blueprint, PaperContext, PlanningNode, ReproductionPlan
 
 
 @pytest.fixture

--- a/tests/unit/repro/test_agents.py
+++ b/tests/unit/repro/test_agents.py
@@ -7,8 +7,8 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from repro.agents.base_agent import AgentResult, AgentStatus, BaseAgent
-from repro.agents.verification_agent import VerificationAgent, VerificationReport
+from paperbot.repro.agents.base_agent import AgentResult, AgentStatus, BaseAgent
+from paperbot.repro.agents.verification_agent import VerificationAgent, VerificationReport
 
 
 class ConcreteAgent(BaseAgent):

--- a/tests/unit/repro/test_blueprint.py
+++ b/tests/unit/repro/test_blueprint.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from repro import (
+from paperbot.repro import (
     AlgorithmSpec,
     Blueprint,
     EnvironmentSpec,

--- a/tests/unit/repro/test_memory.py
+++ b/tests/unit/repro/test_memory.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from repro.memory.code_memory import CodeMemory, FileInfo
-from repro.memory.symbol_index import SymbolIndex, SymbolInfo
+from paperbot.repro.memory.code_memory import CodeMemory, FileInfo
+from paperbot.repro.memory.symbol_index import SymbolIndex, SymbolInfo
 
 
 def test_symbol_info_to_summary_variants():

--- a/tests/unit/repro/test_orchestrator.py
+++ b/tests/unit/repro/test_orchestrator.py
@@ -9,9 +9,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from repro.agents.base_agent import AgentResult, AgentStatus
-from repro.models import PaperContext, ReproPhase
-from repro.orchestrator import (
+from paperbot.repro.agents.base_agent import AgentResult, AgentStatus
+from paperbot.repro.models import PaperContext, ReproPhase
+from paperbot.repro.orchestrator import (
     Orchestrator,
     OrchestratorConfig,
     ParallelOrchestrator,

--- a/tests/unit/repro/test_rag.py
+++ b/tests/unit/repro/test_rag.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from repro.rag.knowledge_base import BUILTIN_PATTERNS, CodeKnowledgeBase, CodePattern
+from paperbot.repro.rag.knowledge_base import BUILTIN_PATTERNS, CodeKnowledgeBase, CodePattern
 
 
 def test_code_pattern_to_context_renders_metadata_and_code():

--- a/tests/unit/test_repro_import_contracts.py
+++ b/tests/unit/test_repro_import_contracts.py
@@ -1,18 +1,30 @@
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
 TESTS_ROOT = ROOT / "tests"
-LEGACY_REPRO_IMPORT_PREFIXES = (
-    "from " + "repro.",
-    "import " + "repro.",
-)
+LEGACY_REPRO_ROOT = "repro"
 
 
 def test_tests_do_not_reference_legacy_repro_package_root() -> None:
     for path in sorted(TESTS_ROOT.rglob("*.py")):
-        content = path.read_text(encoding="utf-8")
-        for prefix in LEGACY_REPRO_IMPORT_PREFIXES:
-            assert prefix not in content, f"{path.relative_to(TESTS_ROOT)}: {prefix}"
+        tree = ast.parse(path.read_text(encoding="utf-8-sig"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name != LEGACY_REPRO_ROOT, (
+                        f"{path.relative_to(TESTS_ROOT)}: import {alias.name}"
+                    )
+                    assert not alias.name.startswith(f"{LEGACY_REPRO_ROOT}."), (
+                        f"{path.relative_to(TESTS_ROOT)}: import {alias.name}"
+                    )
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                assert node.module != LEGACY_REPRO_ROOT, (
+                    f"{path.relative_to(TESTS_ROOT)}: from {node.module} import ..."
+                )
+                assert not node.module.startswith(f"{LEGACY_REPRO_ROOT}."), (
+                    f"{path.relative_to(TESTS_ROOT)}: from {node.module} import ..."
+                )

--- a/tests/unit/test_repro_import_contracts.py
+++ b/tests/unit/test_repro_import_contracts.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = ROOT / "tests"
+LEGACY_REPRO_IMPORT_PREFIXES = (
+    "from " + "repro.",
+    "import " + "repro.",
+)
+
+
+def test_tests_do_not_reference_legacy_repro_package_root() -> None:
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        content = path.read_text(encoding="utf-8")
+        for prefix in LEGACY_REPRO_IMPORT_PREFIXES:
+            assert prefix not in content, f"{path.relative_to(TESTS_ROOT)}: {prefix}"


### PR DESCRIPTION
## Summary
- switch `tests/unit/repro/*` to import from `paperbot.repro.*` instead of relying on the legacy bare `repro.*` root
- remove the temporary `src/paperbot` sys.path compatibility injection from `tests/conftest.py`
- add a contract test to prevent `repro.*` root imports from reappearing in the test suite

## Validation
- `python -m pytest -q tests/unit/repro/test_agents.py tests/unit/repro/test_memory.py tests/unit/repro/test_orchestrator.py tests/unit/repro/test_rag.py tests/unit/test_repro_import_contracts.py`
- `python -m pytest -q tests/unit/test_verification_error_classification.py tests/unit/test_repro_import_contracts.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite organization and modernized internal structure.
  * Added validation to prevent usage of outdated code patterns in tests.
  * Removed outdated test files pending full cleanup.

* **Chores**
  * Updated test configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->