### PR TITLE
fix: align export proxy auth contracts

### DIFF
--- a/web/src/app/api/_utils/auth-headers.test.ts
+++ b/web/src/app/api/_utils/auth-headers.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { authMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+}))
+
+vi.mock("@/auth", () => ({
+  auth: authMock,
+}))
+
+import { backendBaseUrl, withBackendAuth } from "./auth-headers"
+
+describe("backendBaseUrl", () => {
+  const originalBackendBaseUrl = process.env.BACKEND_BASE_URL
+  const originalPaperbotApiBaseUrl = process.env.PAPERBOT_API_BASE_URL
+
+  afterEach(() => {
+    if (originalBackendBaseUrl === undefined) {
+      delete process.env.BACKEND_BASE_URL
+    } else {
+      process.env.BACKEND_BASE_URL = originalBackendBaseUrl
+    }
+
+    if (originalPaperbotApiBaseUrl === undefined) {
+      delete process.env.PAPERBOT_API_BASE_URL
+    } else {
+      process.env.PAPERBOT_API_BASE_URL = originalPaperbotApiBaseUrl
+    }
+  })
+
+  it("falls back to PAPERBOT_API_BASE_URL when BACKEND_BASE_URL is unset", () => {
+    delete process.env.BACKEND_BASE_URL
+    process.env.PAPERBOT_API_BASE_URL = "https://paperbot-api.example.com"
+
+    expect(backendBaseUrl()).toBe("https://paperbot-api.example.com")
+  })
+})
+
+describe("withBackendAuth", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it("prefers the incoming authorization header", async () => {
+    const headers = await withBackendAuth(
+      new Request("http://localhost/api/demo", {
+        headers: { authorization: "Bearer incoming-token" },
+      }),
+      { Accept: "application/json" },
+    )
+
+    expect(authMock).not.toHaveBeenCalled()
+    expect(new Headers(headers).get("authorization")).toBe("Bearer incoming-token")
+  })
+
+  it("uses the server session access token when present", async () => {
+    authMock.mockResolvedValue({ accessToken: "session-token" })
+
+    const headers = await withBackendAuth(new Request("http://localhost/api/demo"), {
+      Accept: "application/json",
+    })
+
+    expect(new Headers(headers).get("authorization")).toBe("Bearer session-token")
+  })
+})

--- a/web/src/app/api/_utils/auth-headers.ts
+++ b/web/src/app/api/_utils/auth-headers.ts
@@ -1,14 +1,36 @@
 import { auth } from "@/auth"
 
+type SessionMetadata = {
+  accessToken?: string
+  provider?: string
+  userId?: string | number
+}
+
+function readSessionMetadata(session: unknown): SessionMetadata {
+  if (!session || typeof session !== "object") {
+    return {}
+  }
+
+  const record = session as Record<string, unknown>
+  return {
+    accessToken: typeof record.accessToken === "string" ? record.accessToken : undefined,
+    provider: typeof record.provider === "string" ? record.provider : undefined,
+    userId:
+      typeof record.userId === "string" || typeof record.userId === "number"
+        ? record.userId
+        : undefined,
+  }
+}
+
 export function backendBaseUrl(): string {
-  return process.env.BACKEND_BASE_URL || "http://127.0.0.1:8000"
+  return process.env.BACKEND_BASE_URL || process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
 }
 
 export async function withBackendAuth(
   req: Request,
-  base: HeadersInit = {}
+  base: HeadersInit = {},
 ): Promise<HeadersInit> {
-  const headers = new Headers(base as any)
+  const headers = new Headers(base)
 
   // Prefer client-provided Authorization header if present
   const incoming = req.headers.get("authorization")
@@ -20,14 +42,14 @@ export async function withBackendAuth(
   // Otherwise pull token from NextAuth session (server-side)
   try {
     const session = await auth()
-    const token = (session as any)?.accessToken as string | undefined
-    if (token) {
-      headers.set("authorization", `Bearer ${token}`)
+    const metadata = readSessionMetadata(session)
+    if (metadata.accessToken) {
+      headers.set("authorization", `Bearer ${metadata.accessToken}`)
     } else {
       console.warn("[auth-headers] session.accessToken is missing", {
         hasSession: !!session,
-        userId: (session as any)?.userId,
-        provider: (session as any)?.provider,
+        userId: metadata.userId,
+        provider: metadata.provider,
       })
     }
   } catch (e) {
@@ -35,4 +57,3 @@ export async function withBackendAuth(
   }
   return headers
 }
-

--- a/web/src/app/api/papers/export/route.test.ts
+++ b/web/src/app/api/papers/export/route.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { withBackendAuthMock } = vi.hoisted(() => ({
+  withBackendAuthMock: vi.fn(),
+}))
+
+vi.mock("@/app/api/_utils/auth-headers", () => ({
+  withBackendAuth: withBackendAuthMock,
+}))
+
+vi.mock("@/app/api/research/_base", () => ({
+  apiBaseUrl: () => "http://backend.example.com",
+}))
+
+import { GET } from "./route"
+
+describe("papers export proxy", () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it("forwards backend auth headers to the protected export endpoint", async () => {
+    withBackendAuthMock.mockResolvedValue({
+      Accept: "*/*",
+      authorization: "Bearer export-token",
+    })
+
+    const fetchMock = vi.fn(async () =>
+      new Response("bibtex-body", {
+        status: 200,
+        headers: {
+          "content-type": "application/x-bibtex",
+          "content-disposition": "attachment; filename=papers.bib",
+        },
+      }),
+    )
+    global.fetch = fetchMock as typeof fetch
+
+    const res = await GET(
+      new Request("http://localhost/api/papers/export?format=bibtex", {
+        method: "GET",
+      }),
+    )
+
+    expect(withBackendAuthMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://backend.example.com/api/research/papers/export?format=bibtex",
+      {
+        method: "GET",
+        headers: {
+          Accept: "*/*",
+          authorization: "Bearer export-token",
+        },
+      },
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe("bibtex-body")
+    expect(res.headers.get("Content-Type")).toBe("application/x-bibtex")
+    expect(res.headers.get("Content-Disposition")).toBe("attachment; filename=papers.bib")
+  })
+})

--- a/web/src/app/api/papers/export/route.ts
+++ b/web/src/app/api/papers/export/route.ts
@@ -1,5 +1,6 @@
 export const runtime = "nodejs"
 
+import { withBackendAuth } from "@/app/api/_utils/auth-headers"
 import { apiBaseUrl } from "@/app/api/research/_base"
 
 export async function GET(req: Request) {
@@ -9,7 +10,7 @@ export async function GET(req: Request) {
   try {
     const res = await fetch(upstream, {
       method: "GET",
-      headers: { Accept: "*/*" },
+      headers: await withBackendAuth(req, { Accept: "*/*" }),
     })
     const body = await res.arrayBuffer()
     return new Response(body, {


### PR DESCRIPTION
## Summary
- let `web/src/app/api/_utils/auth-headers.ts` fall back to `PAPERBOT_API_BASE_URL`, matching the rest of the web proxy layer and documented env contract
- forward backend auth headers from `web/src/app/api/papers/export/route.ts` so the protected export endpoint can use the current user session
- add focused vitest coverage for the auth helper and export proxy contract

## Validation
- `cd web && npm install --no-audit --no-fund`
- `cd web && npx vitest run src/app/api/_utils/auth-headers.test.ts src/app/api/papers/export/route.test.ts`
- `cd web && npx eslint src/app/api/_utils/auth-headers.ts src/app/api/_utils/auth-headers.test.ts src/app/api/papers/export/route.ts src/app/api/papers/export/route.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for authentication header handling and fallback URL resolution
  * Added integration tests for the papers export endpoint to verify proper authentication and header propagation

* **Bug Fixes**
  * Enhanced authentication header handling to preserve existing headers and integrate server session tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->