### PR TITLE
test: refresh cli flag ordering assertions

### DIFF
--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -3,7 +3,9 @@ from main import build_parser
 
 def test_cli_track_flags():
     parser = build_parser()
-    args = parser.parse_args(["track", "--mode", "academic", "--repro", "--report-template", "academic_report.md.j2"])
+    args = parser.parse_args(
+        ["--mode", "academic", "--report-template", "academic_report.md.j2", "track", "--repro"]
+    )
     assert args.command == "track"
     assert args.mode == "academic"
     assert args.repro is True
@@ -15,4 +17,3 @@ def test_cli_render_latest_meta():
     args = parser.parse_args(["render-report"])
     assert args.command == "render-report"
     assert args.meta is None
-


### PR DESCRIPTION
## Summary
- update `tests/test_cli_flags.py` to match the current `main.py` parser contract, where global flags are parsed before the subcommand and `--repro` remains a `track` subcommand flag
- keep the `render-report` expectation unchanged

## Validation
- `python -m pytest -q tests/test_cli_flags.py`
