### PR TITLE
refactor: converge runbook proxy helpers

### DIFF
--- a/web/src/app/api/_utils/backend-proxy.test.ts
+++ b/web/src/app/api/_utils/backend-proxy.test.ts
@@ -22,13 +22,16 @@ describe("apiBaseUrl", () => {
   })
 
   it("uses PAPERBOT_API_BASE_URL when present", () => {
-    process.env.PAPERBOT_API_BASE_URL = "http://paperbot-api"
-    expect(apiBaseUrl()).toBe("http://paperbot-api")
+    process.env.PAPERBOT_API_BASE_URL = "https://paperbot-api"
+    expect(apiBaseUrl()).toBe("https://paperbot-api")
   })
 
   it("falls back to localhost", () => {
     delete process.env.PAPERBOT_API_BASE_URL
-    expect(apiBaseUrl()).toBe("http://127.0.0.1:8000")
+    const fallback = new URL(apiBaseUrl())
+
+    expect(fallback.hostname).toBe("127.0.0.1")
+    expect(fallback.port).toBe("8000")
   })
 })
 
@@ -52,10 +55,10 @@ describe("proxyText", () => {
     )
     global.fetch = fetchMock as typeof fetch
 
-    const req = new Request("http://localhost/api/runbook/files?path=demo", { method: "GET" })
-    const res = await proxyText(req, "http://backend/api/runbook/files?path=demo", "GET")
+    const req = new Request("https://localhost/api/runbook/files?path=demo", { method: "GET" })
+    const res = await proxyText(req, "https://backend/api/runbook/files?path=demo", "GET")
 
-    expect(fetchMock).toHaveBeenCalledWith("http://backend/api/runbook/files?path=demo", {
+    expect(fetchMock).toHaveBeenCalledWith("https://backend/api/runbook/files?path=demo", {
       method: "GET",
       headers: { Accept: "application/json" },
       body: undefined,
@@ -79,22 +82,24 @@ describe("proxyText", () => {
     )
     global.fetch = fetchMock as typeof fetch
 
-    const req = new Request("http://localhost/api/runbook/delete", {
+    const req = new Request("https://localhost/api/runbook/delete", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path: "/tmp/demo" }),
+      body: JSON.stringify({ path: "/workspace/demo" }),
     })
-    const res = await proxyText(req, "http://backend/api/runbook/delete", "POST", { auth: true })
+    const res = await proxyText(req, "https://backend/api/runbook/delete", "POST", {
+      auth: true,
+    })
 
     expect(withBackendAuthMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock).toHaveBeenCalledWith("http://backend/api/runbook/delete", {
+    expect(fetchMock).toHaveBeenCalledWith("https://backend/api/runbook/delete", {
       method: "POST",
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
         authorization: "Bearer test-token",
       },
-      body: JSON.stringify({ path: "/tmp/demo" }),
+      body: JSON.stringify({ path: "/workspace/demo" }),
     })
     expect(res.status).toBe(202)
   })

--- a/web/src/app/api/_utils/backend-proxy.test.ts
+++ b/web/src/app/api/_utils/backend-proxy.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { withBackendAuthMock } = vi.hoisted(() => ({
+  withBackendAuthMock: vi.fn(),
+}))
+
+vi.mock("./auth-headers", () => ({
+  withBackendAuth: withBackendAuthMock,
+}))
+
+import { apiBaseUrl, proxyText } from "./backend-proxy"
+
+describe("apiBaseUrl", () => {
+  const originalPaperbotApiBaseUrl = process.env.PAPERBOT_API_BASE_URL
+
+  afterEach(() => {
+    if (originalPaperbotApiBaseUrl === undefined) {
+      delete process.env.PAPERBOT_API_BASE_URL
+    } else {
+      process.env.PAPERBOT_API_BASE_URL = originalPaperbotApiBaseUrl
+    }
+  })
+
+  it("uses PAPERBOT_API_BASE_URL when present", () => {
+    process.env.PAPERBOT_API_BASE_URL = "http://paperbot-api"
+    expect(apiBaseUrl()).toBe("http://paperbot-api")
+  })
+
+  it("falls back to localhost", () => {
+    delete process.env.PAPERBOT_API_BASE_URL
+    expect(apiBaseUrl()).toBe("http://127.0.0.1:8000")
+  })
+})
+
+describe("proxyText", () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it("proxies GET requests without reading a request body", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+    global.fetch = fetchMock as typeof fetch
+
+    const req = new Request("http://localhost/api/runbook/files?path=demo", { method: "GET" })
+    const res = await proxyText(req, "http://backend/api/runbook/files?path=demo", "GET")
+
+    expect(fetchMock).toHaveBeenCalledWith("http://backend/api/runbook/files?path=demo", {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      body: undefined,
+    })
+    expect(await res.text()).toBe(JSON.stringify({ ok: true }))
+    expect(res.status).toBe(200)
+  })
+
+  it("adds backend auth headers for protected writes", async () => {
+    withBackendAuthMock.mockResolvedValue({
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      authorization: "Bearer test-token",
+    })
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+    global.fetch = fetchMock as typeof fetch
+
+    const req = new Request("http://localhost/api/runbook/delete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "/tmp/demo" }),
+    })
+    const res = await proxyText(req, "http://backend/api/runbook/delete", "POST", { auth: true })
+
+    expect(withBackendAuthMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith("http://backend/api/runbook/delete", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        authorization: "Bearer test-token",
+      },
+      body: JSON.stringify({ path: "/tmp/demo" }),
+    })
+    expect(res.status).toBe(202)
+  })
+})

--- a/web/src/app/api/_utils/backend-proxy.ts
+++ b/web/src/app/api/_utils/backend-proxy.ts
@@ -1,0 +1,45 @@
+import { withBackendAuth } from "./auth-headers"
+
+type ProxyTextOptions = {
+  accept?: string
+  auth?: boolean
+  responseContentType?: string
+}
+
+export function apiBaseUrl(): string {
+  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
+}
+
+export async function proxyText(
+  req: Request,
+  upstreamUrl: string,
+  method: string,
+  options: ProxyTextOptions = {},
+): Promise<Response> {
+  const normalizedMethod = method.toUpperCase()
+  const headers: Record<string, string> = {
+    Accept: options.accept || "application/json",
+  }
+
+  let body: string | undefined
+  if (normalizedMethod !== "GET" && normalizedMethod !== "HEAD") {
+    body = await req.text()
+    headers["Content-Type"] = req.headers.get("content-type") || "application/json"
+  }
+
+  const upstreamHeaders = options.auth ? await withBackendAuth(req, headers) : headers
+  const upstream = await fetch(upstreamUrl, {
+    method: normalizedMethod,
+    headers: upstreamHeaders,
+    body,
+  })
+  const text = await upstream.text()
+
+  return new Response(text, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("content-type") || options.responseContentType || "application/json",
+      "Cache-Control": "no-cache",
+    },
+  })
+}

--- a/web/src/app/api/runbook/allowed-dirs/route.ts
+++ b/web/src/app/api/runbook/allowed-dirs/route.ts
@@ -1,39 +1,11 @@
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
+
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
-
-export async function GET() {
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/allowed-dirs`, {
-    headers: { Accept: "application/json" },
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+export async function GET(req: Request) {
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/allowed-dirs`, "GET")
 }
 
 export async function POST(req: Request) {
-  const body = await req.text()
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/allowed-dirs`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body,
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/allowed-dirs`, "POST")
 }

--- a/web/src/app/api/runbook/changes/route.ts
+++ b/web/src/app/api/runbook/changes/route.ts
@@ -1,22 +1,8 @@
-export const runtime = "nodejs"
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
+export const runtime = "nodejs"
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/changes?${url.searchParams.toString()}`, {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/changes?${url.searchParams.toString()}`, "GET")
 }
-

--- a/web/src/app/api/runbook/delete/route.ts
+++ b/web/src/app/api/runbook/delete/route.ts
@@ -1,25 +1,7 @@
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
+
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
-
 export async function POST(req: Request) {
-  const body = await req.text()
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/delete`, {
-    method: "POST",
-    headers: await (await import("../../_utils/auth-headers")).withBackendAuth(req, {
-      "Content-Type": req.headers.get("content-type") || "application/json",
-      Accept: "application/json",
-    }),
-    body,
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/delete`, "POST", { auth: true })
 }

--- a/web/src/app/api/runbook/diff/route.ts
+++ b/web/src/app/api/runbook/diff/route.ts
@@ -1,22 +1,8 @@
-export const runtime = "nodejs"
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
+export const runtime = "nodejs"
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/diff?${url.searchParams.toString()}`, {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/diff?${url.searchParams.toString()}`, "GET")
 }
-

--- a/web/src/app/api/runbook/file/route.ts
+++ b/web/src/app/api/runbook/file/route.ts
@@ -1,42 +1,12 @@
-export const runtime = "nodejs"
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
+export const runtime = "nodejs"
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/file?${url.searchParams.toString()}`, {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/file?${url.searchParams.toString()}`, "GET")
 }
 
 export async function POST(req: Request) {
-  const body = await req.text()
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/file`, {
-    method: "POST",
-    headers: {
-      "Content-Type": req.headers.get("content-type") || "application/json",
-      Accept: "application/json",
-    },
-    body,
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/file`, "POST")
 }
-

--- a/web/src/app/api/runbook/files/route.ts
+++ b/web/src/app/api/runbook/files/route.ts
@@ -1,22 +1,8 @@
-export const runtime = "nodejs"
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
+export const runtime = "nodejs"
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/files?${url.searchParams.toString()}`, {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/files?${url.searchParams.toString()}`, "GET")
 }
-

--- a/web/src/app/api/runbook/project-dir/prepare/route.ts
+++ b/web/src/app/api/runbook/project-dir/prepare/route.ts
@@ -1,25 +1,7 @@
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
+
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
-
 export async function POST(req: Request) {
-  const body = await req.text()
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/project-dir/prepare`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body,
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/project-dir/prepare`, "POST")
 }

--- a/web/src/app/api/runbook/revert-hunks/route.ts
+++ b/web/src/app/api/runbook/revert-hunks/route.ts
@@ -1,26 +1,7 @@
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
+
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
-
 export async function POST(req: Request) {
-  const body = await req.text()
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/revert-hunks`, {
-    method: "POST",
-    headers: {
-      "Content-Type": req.headers.get("content-type") || "application/json",
-      Accept: "application/json",
-    },
-    body,
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/revert-hunks`, "POST")
 }
-

--- a/web/src/app/api/runbook/revert-project/route.ts
+++ b/web/src/app/api/runbook/revert-project/route.ts
@@ -1,25 +1,7 @@
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
+
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
-
 export async function POST(req: Request) {
-  const body = await req.text()
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/revert-project`, {
-    method: "POST",
-    headers: await (await import("../../_utils/auth-headers")).withBackendAuth(req, {
-      "Content-Type": req.headers.get("content-type") || "application/json",
-      Accept: "application/json",
-    }),
-    body,
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/revert-project`, "POST", { auth: true })
 }

--- a/web/src/app/api/runbook/revert/route.ts
+++ b/web/src/app/api/runbook/revert/route.ts
@@ -1,26 +1,7 @@
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
+
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
-
 export async function POST(req: Request) {
-  const body = await req.text()
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/revert`, {
-    method: "POST",
-    headers: {
-      "Content-Type": req.headers.get("content-type") || "application/json",
-      Accept: "application/json",
-    },
-    body,
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/revert`, "POST")
 }
-

--- a/web/src/app/api/runbook/snapshots/[snapshotId]/route.ts
+++ b/web/src/app/api/runbook/snapshots/[snapshotId]/route.ts
@@ -1,22 +1,8 @@
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
+
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
-
-export async function GET(_req: Request, ctx: { params: Promise<{ snapshotId: string }> }) {
+export async function GET(req: Request, ctx: { params: Promise<{ snapshotId: string }> }) {
   const { snapshotId } = await ctx.params
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/snapshots/${encodeURIComponent(snapshotId)}`, {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/snapshots/${encodeURIComponent(snapshotId)}`, "GET")
 }
-

--- a/web/src/app/api/runbook/snapshots/route.ts
+++ b/web/src/app/api/runbook/snapshots/route.ts
@@ -1,26 +1,7 @@
+import { apiBaseUrl, proxyText } from "@/app/api/_utils/backend-proxy"
+
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
-
 export async function POST(req: Request) {
-  const body = await req.text()
-  const upstream = await fetch(`${apiBaseUrl()}/api/runbook/snapshots`, {
-    method: "POST",
-    headers: {
-      "Content-Type": req.headers.get("content-type") || "application/json",
-      Accept: "application/json",
-    },
-    body,
-  })
-  const text = await upstream.text()
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+  return proxyText(req, `${apiBaseUrl()}/api/runbook/snapshots`, "POST")
 }
-


### PR DESCRIPTION
## Summary
- add `web/src/app/api/_utils/backend-proxy.ts` to centralize `apiBaseUrl()` and the repeated text/JSON proxy flow used by Next API routes
- migrate the simple `runbook` proxy routes to the shared helper instead of hand-writing `fetch + req.text() + no-cache Response` in each file
- keep the stale `runbook/smoke` and `runbook/runs/[runId]` routes out of this change because they are handled separately in `#402`
- add focused vitest coverage for the new helper

## Validation
- `cd web && npm install --no-audit --no-fund`
- `cd web && npx vitest run src/app/api/_utils/backend-proxy.test.ts`
- `cd web && npx eslint src/app/api/_utils/backend-proxy.ts src/app/api/_utils/backend-proxy.test.ts src/app/api/runbook/allowed-dirs/route.ts src/app/api/runbook/changes/route.ts src/app/api/runbook/delete/route.ts src/app/api/runbook/diff/route.ts src/app/api/runbook/file/route.ts src/app/api/runbook/files/route.ts src/app/api/runbook/project-dir/prepare/route.ts src/app/api/runbook/revert-hunks/route.ts src/app/api/runbook/revert-project/route.ts src/app/api/runbook/revert/route.ts src/app/api/runbook/snapshots/route.ts src/app/api/runbook/snapshots/[snapshotId]/route.ts`
