### PR TITLE
refactor: unify auth and sandbox next proxies

### DIFF
--- a/web/src/app/api/_utils/backend-proxy.test.ts
+++ b/web/src/app/api/_utils/backend-proxy.test.ts
@@ -1,45 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const { withBackendAuthMock } = vi.hoisted(() => ({
+const { backendBaseUrlMock, withBackendAuthMock } = vi.hoisted(() => ({
+  backendBaseUrlMock: vi.fn(() => "https://backend.test"),
   withBackendAuthMock: vi.fn(),
 }))
 
 vi.mock("./auth-headers", () => ({
+  backendBaseUrl: backendBaseUrlMock,
   withBackendAuth: withBackendAuthMock,
 }))
 
-import { apiBaseUrl, proxyText } from "./backend-proxy"
+import { apiBaseUrl, proxyJson, proxyText } from "./backend-proxy"
 
 describe("apiBaseUrl", () => {
-  const originalPaperbotApiBaseUrl = process.env.PAPERBOT_API_BASE_URL
-
-  afterEach(() => {
-    if (originalPaperbotApiBaseUrl === undefined) {
-      delete process.env.PAPERBOT_API_BASE_URL
-    } else {
-      process.env.PAPERBOT_API_BASE_URL = originalPaperbotApiBaseUrl
-    }
-  })
-
-  it("uses PAPERBOT_API_BASE_URL when present", () => {
-    process.env.PAPERBOT_API_BASE_URL = "https://paperbot-api"
-    expect(apiBaseUrl()).toBe("https://paperbot-api")
-  })
-
-  it("falls back to localhost", () => {
-    delete process.env.PAPERBOT_API_BASE_URL
-    const fallback = new URL(apiBaseUrl())
-
-    expect(fallback.hostname).toBe("127.0.0.1")
-    expect(fallback.port).toBe("8000")
+  it("uses the shared backend base URL helper", () => {
+    expect(apiBaseUrl()).toBe("https://backend.test")
+    expect(backendBaseUrlMock).toHaveBeenCalledTimes(1)
   })
 })
 
-describe("proxyText", () => {
+describe("backend proxy helpers", () => {
   const originalFetch = global.fetch
 
   beforeEach(() => {
     vi.resetAllMocks()
+    backendBaseUrlMock.mockReturnValue("https://backend.test")
   })
 
   afterEach(() => {
@@ -62,12 +47,13 @@ describe("proxyText", () => {
       method: "GET",
       headers: { Accept: "application/json" },
       body: undefined,
+      signal: expect.any(AbortSignal),
     })
     expect(await res.text()).toBe(JSON.stringify({ ok: true }))
     expect(res.status).toBe(200)
   })
 
-  it("adds backend auth headers for protected writes", async () => {
+  it("proxies JSON writes with backend auth when requested", async () => {
     withBackendAuthMock.mockResolvedValue({
       Accept: "application/json",
       "Content-Type": "application/json",
@@ -83,24 +69,75 @@ describe("proxyText", () => {
     global.fetch = fetchMock as typeof fetch
 
     const req = new Request("https://localhost/api/runbook/delete", {
-      method: "POST",
+      method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path: "/workspace/demo" }),
+      body: JSON.stringify({ display_name: "PaperBot" }),
     })
-    const res = await proxyText(req, "https://backend/api/runbook/delete", "POST", {
+    const res = await proxyJson(req, "https://backend/api/auth/me", "PATCH", {
       auth: true,
     })
 
     expect(withBackendAuthMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock).toHaveBeenCalledWith("https://backend/api/runbook/delete", {
-      method: "POST",
+    expect(fetchMock).toHaveBeenCalledWith("https://backend/api/auth/me", {
+      method: "PATCH",
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
         authorization: "Bearer test-token",
       },
-      body: JSON.stringify({ path: "/workspace/demo" }),
+      body: JSON.stringify({ display_name: "PaperBot" }),
+      signal: expect.any(AbortSignal),
     })
     expect(res.status).toBe(202)
+  })
+
+  it("returns an empty response when the upstream returns 204", async () => {
+    withBackendAuthMock.mockResolvedValue({
+      Accept: "application/json",
+      authorization: "Bearer test-token",
+    })
+
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }))
+    global.fetch = fetchMock as typeof fetch
+
+    const req = new Request("https://localhost/api/auth/me", { method: "DELETE" })
+    const res = await proxyJson(req, "https://backend/api/auth/me", "DELETE", {
+      auth: true,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith("https://backend/api/auth/me", {
+      method: "DELETE",
+      headers: {
+        Accept: "application/json",
+        authorization: "Bearer test-token",
+      },
+      body: undefined,
+      signal: expect.any(AbortSignal),
+    })
+    expect(res.status).toBe(204)
+    expect(await res.text()).toBe("")
+  })
+
+  it("supports custom error handlers for upstream failures", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("boom")
+    })
+    global.fetch = fetchMock as typeof fetch
+
+    const res = await proxyJson(
+      new Request("https://localhost/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "paperbot@example.com" }),
+      }),
+      "https://backend/api/auth/login",
+      "POST",
+      {
+        onError: () => Response.json({ detail: "Service unavailable" }, { status: 502 }),
+      },
+    )
+
+    expect(res.status).toBe(502)
+    await expect(res.json()).resolves.toEqual({ detail: "Service unavailable" })
   })
 })

--- a/web/src/app/api/_utils/backend-proxy.ts
+++ b/web/src/app/api/_utils/backend-proxy.ts
@@ -1,45 +1,181 @@
-import { withBackendAuth } from "./auth-headers"
+import { backendBaseUrl, withBackendAuth } from "./auth-headers"
 
-type ProxyTextOptions = {
-  accept?: string
-  auth?: boolean
-  responseContentType?: string
+export type ProxyMethod = "DELETE" | "GET" | "HEAD" | "PATCH" | "POST" | "PUT"
+
+type ProxyErrorContext = {
+  error: unknown
+  isTimeout: boolean
+  upstreamUrl: string
 }
 
+type ProxyOptions = {
+  accept?: string
+  auth?: boolean
+  contentType?: string
+  onError?: (context: ProxyErrorContext) => Response
+  timeoutMs?: number
+}
+
+type TextProxyOptions = ProxyOptions & {
+  responseContentType?: string
+  responseHeaders?: HeadersInit
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000
+
 export function apiBaseUrl(): string {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
+  return backendBaseUrl()
+}
+
+export async function proxyJson(
+  req: Request,
+  upstreamUrl: string,
+  method: ProxyMethod,
+  options: TextProxyOptions = {},
+): Promise<Response> {
+  return proxyText(req, upstreamUrl, method, {
+    accept: options.accept ?? "application/json",
+    responseContentType: options.responseContentType ?? "application/json",
+    ...options,
+  })
 }
 
 export async function proxyText(
   req: Request,
   upstreamUrl: string,
-  method: string,
-  options: ProxyTextOptions = {},
+  method: ProxyMethod,
+  options: TextProxyOptions = {},
 ): Promise<Response> {
-  const normalizedMethod = method.toUpperCase()
-  const headers: Record<string, string> = {
-    Accept: options.accept || "application/json",
+  const requestOptions = {
+    accept: "application/json",
+    ...options,
   }
 
-  let body: string | undefined
-  if (normalizedMethod !== "GET" && normalizedMethod !== "HEAD") {
-    body = await req.text()
-    headers["Content-Type"] = req.headers.get("content-type") || "application/json"
+  try {
+    const upstream = await fetchUpstream(req, upstreamUrl, method, requestOptions)
+    const text = await upstream.text()
+
+    return buildTextResponse(text, upstream, {
+      responseContentType: requestOptions.responseContentType,
+      responseHeaders: requestOptions.responseHeaders,
+    })
+  } catch (error) {
+    return handleProxyError(error, upstreamUrl, requestOptions.onError)
+  }
+}
+
+async function fetchUpstream(
+  req: Request,
+  upstreamUrl: string,
+  method: ProxyMethod,
+  options: ProxyOptions,
+): Promise<Response> {
+  const controller = options.timeoutMs === 0 ? null : new AbortController()
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null
+  const body = await resolveBody(req, method)
+
+  try {
+    return await fetch(upstreamUrl, {
+      method,
+      headers: await resolveHeaders(req, body, options),
+      body,
+      signal: controller?.signal,
+    })
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+async function resolveHeaders(
+  req: Request,
+  body: string | undefined,
+  options: ProxyOptions,
+): Promise<HeadersInit> {
+  const headers: Record<string, string> = {}
+
+  if (options.accept) {
+    headers.Accept = options.accept
   }
 
-  const upstreamHeaders = options.auth ? await withBackendAuth(req, headers) : headers
-  const upstream = await fetch(upstreamUrl, {
-    method: normalizedMethod,
-    headers: upstreamHeaders,
-    body,
-  })
-  const text = await upstream.text()
+  if (body !== undefined) {
+    headers["Content-Type"] =
+      options.contentType || req.headers.get("content-type") || "application/json"
+  }
+
+  if (options.auth) {
+    return withBackendAuth(req, headers)
+  }
+
+  return headers
+}
+
+async function resolveBody(
+  req: Request,
+  method: ProxyMethod,
+): Promise<string | undefined> {
+  if (method === "GET" || method === "HEAD" || req.body === null) {
+    return undefined
+  }
+
+  return req.text()
+}
+
+function buildTextResponse(
+  text: string,
+  upstream: Response,
+  options: Pick<TextProxyOptions, "responseContentType" | "responseHeaders">,
+): Response {
+  const headers = new Headers(options.responseHeaders)
+  headers.set("Cache-Control", "no-cache")
+
+  const contentType =
+    upstream.headers.get("content-type") || options.responseContentType
+
+  if (contentType && upstream.status !== 204 && text.length > 0) {
+    headers.set("Content-Type", contentType)
+  }
+
+  if (upstream.status === 204 || text.length === 0) {
+    return new Response(null, {
+      status: upstream.status,
+      headers,
+    })
+  }
 
   return new Response(text, {
     status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || options.responseContentType || "application/json",
-      "Cache-Control": "no-cache",
-    },
+    headers,
   })
+}
+
+function handleProxyError(
+  error: unknown,
+  upstreamUrl: string,
+  onError?: (context: ProxyErrorContext) => Response,
+): Response {
+  const isTimeout = error instanceof Error && error.name === "AbortError"
+  const context = {
+    error,
+    isTimeout,
+    upstreamUrl,
+  }
+
+  if (onError) {
+    return onError(context)
+  }
+
+  const detail = error instanceof Error ? error.message : String(error)
+
+  return Response.json(
+    {
+      detail: isTimeout
+        ? `Upstream API timed out: ${upstreamUrl}`
+        : `Upstream API unreachable: ${upstreamUrl}`,
+      error: detail,
+    },
+    { status: 502 },
+  )
 }

--- a/web/src/app/api/auth/forgot-password/route.ts
+++ b/web/src/app/api/auth/forgot-password/route.ts
@@ -1,13 +1,5 @@
-import { NextRequest, NextResponse } from "next/server"
-import { backendBaseUrl } from "@/app/api/_utils/auth-headers"
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-export async function POST(req: NextRequest) {
-  const body = await req.json()
-  const res = await fetch(`${backendBaseUrl()}/api/auth/forgot-password`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  })
-  const data = await res.json().catch(() => null)
-  return NextResponse.json(data, { status: res.status })
+export async function POST(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/auth/forgot-password`, "POST")
 }

--- a/web/src/app/api/auth/login-check/route.ts
+++ b/web/src/app/api/auth/login-check/route.ts
@@ -1,19 +1,9 @@
 export const runtime = "nodejs"
 
-import { backendBaseUrl } from "../../_utils/auth-headers"
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
 export async function POST(req: Request) {
-  const body = await req.text()
-  const res = await fetch(`${backendBaseUrl()}/api/auth/login`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body,
-  }).catch(() => null)
-
-  if (!res) return Response.json({ detail: "Service unavailable" }, { status: 502 })
-  const text = await res.text()
-  return new Response(text, {
-    status: res.status,
-    headers: { "Content-Type": "application/json" },
+  return proxyJson(req, `${apiBaseUrl()}/api/auth/login`, "POST", {
+    onError: () => Response.json({ detail: "Service unavailable" }, { status: 502 }),
   })
 }

--- a/web/src/app/api/auth/me/change-password/route.ts
+++ b/web/src/app/api/auth/me/change-password/route.ts
@@ -1,14 +1,7 @@
-import { NextRequest, NextResponse } from "next/server"
-import { backendBaseUrl, withBackendAuth } from "@/app/api/_utils/auth-headers"
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-export async function POST(req: NextRequest) {
-  const body = await req.json()
-  const headers = await withBackendAuth(req, { "Content-Type": "application/json" })
-  const res = await fetch(`${backendBaseUrl()}/api/auth/me/change-password`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
+export async function POST(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/auth/me/change-password`, "POST", {
+    auth: true,
   })
-  const data = await res.json().catch(() => null)
-  return NextResponse.json(data, { status: res.status })
 }

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -1,27 +1,13 @@
-import { NextRequest, NextResponse } from "next/server"
-import { backendBaseUrl, withBackendAuth } from "@/app/api/_utils/auth-headers"
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-export async function GET(req: NextRequest) {
-  const headers = await withBackendAuth(req)
-  const res = await fetch(`${backendBaseUrl()}/api/auth/me`, { headers })
-  const data = await res.json().catch(() => null)
-  return NextResponse.json(data, { status: res.status })
+export async function GET(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/auth/me`, "GET", { auth: true })
 }
 
-export async function PATCH(req: NextRequest) {
-  const body = await req.json()
-  const headers = await withBackendAuth(req, { "Content-Type": "application/json" })
-  const res = await fetch(`${backendBaseUrl()}/api/auth/me`, {
-    method: "PATCH",
-    headers,
-    body: JSON.stringify(body),
-  })
-  const data = await res.json().catch(() => null)
-  return NextResponse.json(data, { status: res.status })
+export async function PATCH(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/auth/me`, "PATCH", { auth: true })
 }
 
-export async function DELETE(req: NextRequest) {
-  const headers = await withBackendAuth(req)
-  const res = await fetch(`${backendBaseUrl()}/api/auth/me`, { method: "DELETE", headers })
-  return new NextResponse(null, { status: res.status })
+export async function DELETE(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/auth/me`, "DELETE", { auth: true })
 }

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -1,13 +1,5 @@
-import { NextRequest, NextResponse } from "next/server"
-import { backendBaseUrl } from "@/app/api/_utils/auth-headers"
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-export async function POST(req: NextRequest) {
-  const body = await req.json()
-  const res = await fetch(`${backendBaseUrl()}/api/auth/register`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  })
-  const data = await res.json().catch(() => null)
-  return NextResponse.json(data, { status: res.status })
+export async function POST(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/auth/register`, "POST")
 }

--- a/web/src/app/api/auth/reset-password/route.ts
+++ b/web/src/app/api/auth/reset-password/route.ts
@@ -1,13 +1,5 @@
-import { NextRequest, NextResponse } from "next/server"
-import { backendBaseUrl } from "@/app/api/_utils/auth-headers"
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-export async function POST(req: NextRequest) {
-  const body = await req.json()
-  const res = await fetch(`${backendBaseUrl()}/api/auth/reset-password`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  })
-  const data = await res.json().catch(() => null)
-  return NextResponse.json(data, { status: res.status })
+export async function POST(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/auth/reset-password`, "POST")
 }

--- a/web/src/app/api/sandbox/status/route.ts
+++ b/web/src/app/api/sandbox/status/route.ts
@@ -1,18 +1,7 @@
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-export async function GET() {
-  const upstream = await fetch(`${apiBaseUrl()}/api/sandbox/status`, { method: "GET" })
-  const text = await upstream.text()
-
-  return new Response(text, {
-    status: upstream.status,
-    headers: {
-      "Content-Type": upstream.headers.get("content-type") || "application/json",
-      "Cache-Control": "no-cache",
-    },
-  })
+export async function GET(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/sandbox/status`, "GET")
 }


### PR DESCRIPTION
## What changed
- expand `web/src/app/api/_utils/backend-proxy.ts` into a shared JSON/text proxy layer with timeout handling, upstream error fallbacks, and unified backend base URL resolution
- migrate auth proxy routes (`forgot-password`, `register`, `reset-password`, `me`, `me/change-password`, `login-check`) to the shared helper
- migrate `sandbox/status` to the same helper and add focused helper tests for auth passthrough, empty 204 responses, and custom 502 fallbacks

## Why
- removes duplicated Next API proxy logic and aligns auth/sandbox routes on one contract
- keeps this PR limited to non-streaming, non-binary proxy routes so review stays small
- leaves streaming/download/fallback-specialized routes for follow-up PRs

## Validation
- `npx vitest run src/app/api/_utils/backend-proxy.test.ts src/app/api/_utils/auth-headers.test.ts src/app/api/papers/export/route.test.ts`
- `npx eslint src/app/api/_utils/backend-proxy.ts src/app/api/_utils/backend-proxy.test.ts src/app/api/auth/forgot-password/route.ts src/app/api/auth/register/route.ts src/app/api/auth/reset-password/route.ts src/app/api/auth/me/change-password/route.ts src/app/api/auth/me/route.ts src/app/api/auth/login-check/route.ts src/app/api/sandbox/status/route.ts`
- `npx tsc --noEmit`
- `npm run build`

## Follow-up
- remaining direct backend fetch routes are now the streaming/download/html-fallback/no-store cases and should land as separate PRs