### PR TITLE
refactor: unify fallback next json proxies

### DIFF
--- a/web/src/app/api/_utils/backend-proxy.test.ts
+++ b/web/src/app/api/_utils/backend-proxy.test.ts
@@ -140,4 +140,36 @@ describe("backend proxy helpers", () => {
     expect(res.status).toBe(502)
     await expect(res.json()).resolves.toEqual({ detail: "Service unavailable" })
   })
+
+  it("forwards cache directives to the upstream request", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+    global.fetch = fetchMock as typeof fetch
+
+    const req = new Request("https://localhost/api/research/paperscool/sessions/demo", {
+      method: "GET",
+    })
+    const res = await proxyJson(
+      req,
+      "https://backend/api/research/paperscool/sessions/demo",
+      "GET",
+      { cache: "no-store" },
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://backend/api/research/paperscool/sessions/demo",
+      {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        body: undefined,
+        cache: "no-store",
+        signal: expect.any(AbortSignal),
+      },
+    )
+    expect(res.status).toBe(200)
+  })
 })

--- a/web/src/app/api/_utils/backend-proxy.ts
+++ b/web/src/app/api/_utils/backend-proxy.ts
@@ -11,6 +11,7 @@ type ProxyErrorContext = {
 type ProxyOptions = {
   accept?: string
   auth?: boolean
+  cache?: RequestCache
   contentType?: string
   onError?: (context: ProxyErrorContext) => Response
   timeoutMs?: number
@@ -80,6 +81,7 @@ async function fetchUpstream(
       method,
       headers: await resolveHeaders(req, body, options),
       body,
+      cache: options.cache,
       signal: controller?.signal,
     })
   } finally {

--- a/web/src/app/api/research/paperscool/sessions/[sessionId]/route.test.ts
+++ b/web/src/app/api/research/paperscool/sessions/[sessionId]/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { apiBaseUrlMock, proxyJsonMock } = vi.hoisted(() => ({
+  apiBaseUrlMock: vi.fn(() => "http://backend.example.com"),
+  proxyJsonMock: vi.fn(),
+}))
+
+vi.mock("@/app/api/_utils/backend-proxy", () => ({
+  apiBaseUrl: apiBaseUrlMock,
+  proxyJson: proxyJsonMock,
+}))
+
+import { GET } from "./route"
+
+describe("paperscool session route", () => {
+  it("proxies the backend request without caching", async () => {
+    const req = new Request("http://localhost/api/research/paperscool/sessions/some/session")
+    proxyJsonMock.mockResolvedValueOnce(Response.json({ ok: true }))
+
+    await GET(req, { params: Promise.resolve({ sessionId: "session/42" }) })
+
+    expect(proxyJsonMock).toHaveBeenCalledWith(
+      req,
+      "http://backend.example.com/api/research/paperscool/sessions/session%2F42",
+      "GET",
+      { cache: "no-store" },
+    )
+  })
+})

--- a/web/src/app/api/research/paperscool/sessions/[sessionId]/route.ts
+++ b/web/src/app/api/research/paperscool/sessions/[sessionId]/route.ts
@@ -1,17 +1,11 @@
-import { NextResponse } from "next/server"
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-import { apiBaseUrl } from "@/app/api/research/_base"
-
-export async function GET(_req: Request, ctx: { params: Promise<{ sessionId: string }> }) {
+export async function GET(req: Request, ctx: { params: Promise<{ sessionId: string }> }) {
   const { sessionId } = await ctx.params
-  const upstream = await fetch(
+  return proxyJson(
+    req,
     `${apiBaseUrl()}/api/research/paperscool/sessions/${encodeURIComponent(sessionId)}`,
+    "GET",
     { cache: "no-store" },
   )
-
-  const body = await upstream.text()
-  return new NextResponse(body, {
-    status: upstream.status,
-    headers: { "Content-Type": upstream.headers.get("content-type") || "application/json" },
-  })
 }

--- a/web/src/app/api/studio/cwd/route.test.ts
+++ b/web/src/app/api/studio/cwd/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { apiBaseUrlMock, proxyJsonMock } = vi.hoisted(() => ({
+  apiBaseUrlMock: vi.fn(() => "http://backend.example.com"),
+  proxyJsonMock: vi.fn(),
+}))
+
+vi.mock("@/app/api/_utils/backend-proxy", () => ({
+  apiBaseUrl: apiBaseUrlMock,
+  proxyJson: proxyJsonMock,
+}))
+
+import { GET } from "./route"
+
+describe("studio cwd route", () => {
+  it("proxies the backend request with a fallback response", async () => {
+    const req = new Request("http://localhost/api/studio/cwd")
+    proxyJsonMock.mockResolvedValueOnce(Response.json({ cwd: "/workspace" }))
+
+    await GET(req)
+
+    expect(proxyJsonMock).toHaveBeenCalledWith(
+      req,
+      "http://backend.example.com/api/studio/cwd",
+      "GET",
+      expect.objectContaining({
+        onError: expect.any(Function),
+      }),
+    )
+
+    const options = vi.mocked(proxyJsonMock).mock.calls[0][3]
+    expect(options).toBeDefined()
+
+    const fallback = options?.onError?.({
+      error: new Error("offline"),
+      isTimeout: false,
+      upstreamUrl: "http://backend.example.com/api/studio/cwd",
+    })
+
+    expect(fallback).toBeInstanceOf(Response)
+    expect(fallback?.status).toBe(200)
+    await expect(fallback?.json()).resolves.toEqual({
+      cwd: process.env.HOME || "/tmp",
+      source: "fallback",
+      error: "Failed to get working directory from backend",
+    })
+  })
+})

--- a/web/src/app/api/studio/cwd/route.ts
+++ b/web/src/app/api/studio/cwd/route.ts
@@ -1,32 +1,17 @@
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-export async function GET() {
-  try {
-    const upstream = await fetch(`${apiBaseUrl()}/api/studio/cwd`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    })
-
-    const data = await upstream.json()
-
-    return Response.json(data, {
-      status: upstream.status,
-    })
-  } catch (error) {
-    // Return a sensible default if backend is unavailable
-    return Response.json(
-      {
-        cwd: process.env.HOME || "/tmp",
-        source: "fallback",
-        error: "Failed to get working directory from backend",
-      },
-      { status: 200 }
-    )
-  }
+export async function GET(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/studio/cwd`, "GET", {
+    onError: () =>
+      Response.json(
+        {
+          cwd: process.env.HOME || "/tmp",
+          source: "fallback",
+          error: "Failed to get working directory from backend",
+        },
+        { status: 200 },
+      ),
+  })
 }

--- a/web/src/app/api/studio/status/route.test.ts
+++ b/web/src/app/api/studio/status/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { apiBaseUrlMock, proxyJsonMock } = vi.hoisted(() => ({
+  apiBaseUrlMock: vi.fn(() => "http://backend.example.com"),
+  proxyJsonMock: vi.fn(),
+}))
+
+vi.mock("@/app/api/_utils/backend-proxy", () => ({
+  apiBaseUrl: apiBaseUrlMock,
+  proxyJson: proxyJsonMock,
+}))
+
+import { GET } from "./route"
+
+describe("studio status route", () => {
+  it("proxies the backend request with a fallback response", async () => {
+    const req = new Request("http://localhost/api/studio/status")
+    proxyJsonMock.mockResolvedValueOnce(Response.json({ claude_cli: true }))
+
+    await GET(req)
+
+    expect(proxyJsonMock).toHaveBeenCalledWith(
+      req,
+      "http://backend.example.com/api/studio/status",
+      "GET",
+      expect.objectContaining({
+        onError: expect.any(Function),
+      }),
+    )
+
+    const options = vi.mocked(proxyJsonMock).mock.calls[0][3]
+    expect(options).toBeDefined()
+
+    const fallback = options?.onError?.({
+      error: new Error("offline"),
+      isTimeout: false,
+      upstreamUrl: "http://backend.example.com/api/studio/status",
+    })
+
+    expect(fallback).toBeInstanceOf(Response)
+    expect(fallback?.status).toBe(500)
+    await expect(fallback?.json()).resolves.toEqual({
+      claude_cli: false,
+      error: "Failed to check Claude CLI status",
+      fallback: "anthropic_api",
+    })
+  })
+})

--- a/web/src/app/api/studio/status/route.ts
+++ b/web/src/app/api/studio/status/route.ts
@@ -1,31 +1,17 @@
 export const runtime = "nodejs"
 
-function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
-}
+import { apiBaseUrl, proxyJson } from "@/app/api/_utils/backend-proxy"
 
-export async function GET() {
-  try {
-    const upstream = await fetch(`${apiBaseUrl()}/api/studio/status`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    })
-
-    const data = await upstream.json()
-
-    return Response.json(data, {
-      status: upstream.status,
-    })
-  } catch (error) {
-    return Response.json(
-      {
-        claude_cli: false,
-        error: "Failed to check Claude CLI status",
-        fallback: "anthropic_api"
-      },
-      { status: 500 }
-    )
-  }
+export async function GET(req: Request) {
+  return proxyJson(req, `${apiBaseUrl()}/api/studio/status`, "GET", {
+    onError: () =>
+      Response.json(
+        {
+          claude_cli: false,
+          error: "Failed to check Claude CLI status",
+          fallback: "anthropic_api",
+        },
+        { status: 500 },
+      ),
+  })
 }


### PR DESCRIPTION
## What changed
- add `cache` support to the shared Next backend proxy helper so routes can preserve `cache: "no-store"`
- migrate `web/src/app/api/studio/cwd`, `web/src/app/api/studio/status`, and `web/src/app/api/research/paperscool/sessions/[sessionId]` to the shared proxy helper
- keep existing route-specific fallback contracts by expressing them through `onError` instead of inline `fetch`/`try` blocks
- add focused route tests for studio fallback behavior and paperscool session no-store proxying

## Why
- continues the proxy cleanup from #407 without mixing in streaming, binary download, or HTML fallback routes
- removes three more hand-rolled backend fetch handlers while preserving their special behavior
- leaves only the streaming/download/html special cases as remaining direct backend fetch routes

## Validation
- `npx vitest run src/app/api/_utils/backend-proxy.test.ts src/app/api/_utils/auth-headers.test.ts src/app/api/papers/export/route.test.ts src/app/api/studio/cwd/route.test.ts src/app/api/studio/status/route.test.ts src/app/api/research/paperscool/sessions/[sessionId]/route.test.ts`
- `npx eslint src/app/api/_utils/backend-proxy.ts src/app/api/_utils/backend-proxy.test.ts src/app/api/studio/cwd/route.ts src/app/api/studio/cwd/route.test.ts src/app/api/studio/status/route.ts src/app/api/studio/status/route.test.ts src/app/api/research/paperscool/sessions/[sessionId]/route.ts src/app/api/research/paperscool/sessions/[sessionId]/route.test.ts`
- `npx tsc --noEmit`
- `npm run build`

## Follow-up
- remaining direct backend fetch routes are now down to 7, all in the streaming / binary / HTML-fallback bucket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache directive support to the backend proxy layer for configurable caching behavior
  * Implemented fallback error responses for studio endpoints when backend requests fail
  * Centralized API proxy handling for research and studio routes

* **Tests**
  * Added comprehensive unit tests for proxy functionality and API route handlers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->