### PR TITLE
refactor: dedupe research proxy base

### DIFF
--- a/web/src/app/api/research/_base.test.ts
+++ b/web/src/app/api/research/_base.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { sharedApiBaseUrlMock, sharedProxyJsonMock } = vi.hoisted(() => ({
+  sharedApiBaseUrlMock: vi.fn(() => "https://backend.test"),
+  sharedProxyJsonMock: vi.fn(),
+}))
+
+vi.mock("../_utils/backend-proxy", () => ({
+  apiBaseUrl: sharedApiBaseUrlMock,
+  proxyJson: sharedProxyJsonMock,
+}))
+
+import { apiBaseUrl, proxyJson } from "./_base"
+
+describe("research base proxy", () => {
+  it("delegates backend base URL resolution to the shared helper", () => {
+    expect(apiBaseUrl()).toBe("https://backend.test")
+    expect(sharedApiBaseUrlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("forces backend auth when delegating JSON proxies", async () => {
+    const req = new Request("https://localhost/api/research/tracks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "demo" }),
+    })
+    const response = Response.json({ ok: true }, { status: 201 })
+    sharedProxyJsonMock.mockResolvedValueOnce(response)
+
+    const res = await proxyJson(req, "https://backend/api/research/tracks", "POST")
+
+    expect(sharedProxyJsonMock).toHaveBeenCalledWith(
+      req,
+      "https://backend/api/research/tracks",
+      "POST",
+      { auth: true },
+    )
+    expect(res).toBe(response)
+  })
+})

--- a/web/src/app/api/research/_base.ts
+++ b/web/src/app/api/research/_base.ts
@@ -1,47 +1,17 @@
-export function apiBaseUrl() {
-  return process.env.PAPERBOT_API_BASE_URL || "http://127.0.0.1:8000"
+import {
+  apiBaseUrl as sharedApiBaseUrl,
+  proxyJson as sharedProxyJson,
+  type ProxyMethod,
+} from "../_utils/backend-proxy"
+
+export function apiBaseUrl(): string {
+  return sharedApiBaseUrl()
 }
 
-export async function proxyJson(req: Request, upstreamUrl: string, method: string) {
-  const body = method === "GET" ? undefined : await req.text()
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 120_000) // 2 min timeout
-
-  try {
-    const baseHeaders = {
-      method,
-      Accept: "application/json",
-      "Content-Type": req.headers.get("content-type") || "application/json",
-    } as Record<string, string>
-    const { withBackendAuth } = await import("../_utils/auth-headers")
-    const headers = await withBackendAuth(req, baseHeaders)
-    const upstream = await fetch(upstreamUrl, {
-      method,
-      headers,
-      body,
-      signal: controller.signal,
-    })
-    const text = await upstream.text()
-    return new Response(text, {
-      status: upstream.status,
-      headers: {
-        "Content-Type": upstream.headers.get("content-type") || "application/json",
-        "Cache-Control": "no-cache",
-      },
-    })
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error)
-    const isTimeout = error instanceof Error && error.name === "AbortError"
-    return Response.json(
-      {
-        detail: isTimeout
-          ? `Upstream API timed out: ${upstreamUrl}`
-          : `Upstream API unreachable: ${upstreamUrl}`,
-        error: detail,
-      },
-      { status: 502 },
-    )
-  } finally {
-    clearTimeout(timeout)
-  }
+export function proxyJson(
+  req: Request,
+  upstreamUrl: string,
+  method: ProxyMethod,
+): Promise<Response> {
+  return sharedProxyJson(req, upstreamUrl, method, { auth: true })
 }


### PR DESCRIPTION
## Summary
- replace the legacy `research/_base.ts` implementation with a thin adapter over the shared backend proxy helper
- preserve the existing `apiBaseUrl` / `proxyJson` call surface while forcing `auth: true` at the delegation boundary
- add a focused `_base` contract test so the auth-default behavior stays locked

## Why
`research/_base.ts` had drifted into a second JSON proxy stack and was being reused well outside `research/`. This PR removes that duplicate implementation without widening review scope to dozens of route import rewrites.

## Validation
- `cd web && npx vitest run src/app/api/research/_base.test.ts src/app/api/research/repro/context/route.test.ts src/app/api/_utils/backend-proxy.test.ts`
- `cd web && npx eslint src/app/api/research/_base.ts src/app/api/research/_base.test.ts`
- `cd web && npx tsc --noEmit`
- `cd web && npm run build`
