### PR TITLE
feat: hide sidebar on login page

### DIFF
--- a/web/src/components/layout/LayoutShell.tsx
+++ b/web/src/components/layout/LayoutShell.tsx
@@ -9,7 +9,7 @@ export function LayoutShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(true)
   const pathname = usePathname()
   const isAgentBoardFocusPage = pathname.startsWith("/studio/agent-board/")
-  const isAuthPage = pathname === "/login"
+  const isAuthPage = ["/login", "/register", "/forgot-password"].includes(pathname)
   const hideSidebar = isAgentBoardFocusPage || isAuthPage
 
   return (

--- a/web/src/components/layout/LayoutShell.tsx
+++ b/web/src/components/layout/LayoutShell.tsx
@@ -9,10 +9,12 @@ export function LayoutShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(true)
   const pathname = usePathname()
   const isAgentBoardFocusPage = pathname.startsWith("/studio/agent-board/")
+  const isAuthPage = pathname === "/login"
+  const hideSidebar = isAgentBoardFocusPage || isAuthPage
 
   return (
     <div className="flex min-h-screen">
-      {!isAgentBoardFocusPage && (
+      {!hideSidebar && (
         <aside
           className={cn(
             "fixed inset-y-0 z-50 hidden flex-col border-r bg-background transition-all duration-200 md:flex",
@@ -25,7 +27,7 @@ export function LayoutShell({ children }: { children: React.ReactNode }) {
       <main
         className={cn(
           "flex-1 transition-all duration-200",
-          !isAgentBoardFocusPage && (collapsed ? "md:pl-14" : "md:pl-56"),
+          !hideSidebar && (collapsed ? "md:pl-14" : "md:pl-56"),
         )}
       >
         {children}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar now hides correctly on login, registration, forgot-password, and agent-board pages.
  * Main content padding now correctly adjusts based on whether the sidebar is shown or hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->